### PR TITLE
Module to revert Raspbian's "no password for sudo"

### DIFF
--- a/src/modules/password-for-sudo/start_chroot_script
+++ b/src/modules/password-for-sudo/start_chroot_script
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# password-for-sudo
+#
+# Reverts Raspbian's default of allowing sudo to be always invoked without having to
+# reenter the user's password.
+#
+# Written by Gina Häußge <gina@octoprint.org>
+# GPL V3
+########
+
+source /common.sh
+install_cleanup_trap
+
+# do NOT allow passwordless sudo for all commands for the user pi (taken from raspberrypi-sys-mods postinst script)
+[ -f /etc/sudoers.d/010_pi-nopasswd ] && sed -e '/^pi/ s/^#*/#/' -i /etc/sudoers.d/010_pi-nopasswd


### PR DESCRIPTION
As suggested in guysoft/OctoPi#345.

I have to admit that I wasn't able to test this yet against an actual build, but this should boil down to the same change.
