### PR TITLE
Fix /etc/custompios_buildbase & add /etc/<dist>_version

### DIFF
--- a/src/modules/base/start_chroot_script
+++ b/src/modules/base/start_chroot_script
@@ -41,4 +41,7 @@ then
 fi
 
 # Store version buildbase
-echo "$CUSTOM_PI_OS_BUILDBASE_BUILDBASE" > /etc/custompios_buildbase
+echo "$CUSTOM_PI_OS_BUILDBASE" > /etc/custompios_buildbase
+
+# Store dist version
+echo "$DIST_VERSION" > /etc/${DIST_NAME,,}_version


### PR DESCRIPTION
`/etc/custompios_buildbase` was empty before that. And the return of `/etc/<distname>_version` trivializes figuring out what distribution version a flashed image actually runs (see also my comment on https://github.com/guysoft/OctoPi/commit/36af82350c20e69543bf3467c12fa188f08ad577 on why this is desirable to have).