### PR TITLE
Properly detect build errors

### DIFF
--- a/src/build_custom_os
+++ b/src/build_custom_os
@@ -1,11 +1,8 @@
 #!/usr/bin/env bash
+set -e
 set -x
 echo "Distro path: ${DIST_PATH}"
 echo "CustomPiOS path: ${CUSTOM_PI_OS_PATH}"
 echo "================================================================"
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ${DIR}/build $1
-exit_code=$?
-if [ $exit_code -ne 0 ]; then
-    exit $exit_code
-fi

--- a/src/common.sh
+++ b/src/common.sh
@@ -21,12 +21,16 @@ function pause() {
   read -p "$*"
 }
 
-function echo_red(){
-  echo -e "\e[91m$1\e[0m"
+function echo_red() {
+  echo -e -n "\e[91m"
+  echo $@
+  echo -e -n "\e[0m"
 }
 
-function echo_green(){
-  echo -e "\e[92m$1\e[0m"
+function echo_green() {
+  echo -e -n "\e[92m"
+  echo $@
+  echo -e -n "\e[0m"
 }
 
 function gitclone(){

--- a/src/common.sh
+++ b/src/common.sh
@@ -188,20 +188,21 @@ function cleanup() {
 }
 
 function install_fail_on_error_trap() {
+  # unmounts image, logs PRINT FAILED to log & console on error
   set -e
-  trap 'previous_command=$this_command; this_command=$BASH_COMMAND' DEBUG
-  trap 'if [ $? -ne 0 ]; then echo_red -e "\nexit $? due to $previous_command \nBUILD FAILED!" && echo_red "unmounting image..." && ( unmount_image $BASE_MOUNT_PATH force || true ); fi;' EXIT
+  trap 'echo "build failed, unmounting image..." && cd $DIST_PATH && ( unmount_image $BASE_MOUNT_PATH force || true ) && echo_red -e "\nBUILD FAILED!\n"' ERR
 }
 
 function install_chroot_fail_on_error_trap() {
+  # logs PRINT FAILED to log & console on error
   set -e
-  trap 'previous_command=$this_command; this_command=$BASH_COMMAND' DEBUG
-  trap 'if [ $? -ne 0 ]; then echo_red -e "\nexit $? due to $previous_command \nBUILD FAILED!"; fi;' EXIT
+  trap 'echo_red -e "\nBUILD FAILED!\n"' ERR
 }
 
 function install_cleanup_trap() {
+  # kills all child processes of the current process on SIGINT or SIGTERM
   set -e
-  trap "cleanup" SIGINT SIGTERM
+  trap 'cleanup' SIGINT SIGTERM
  }
 
 function enlarge_ext() {

--- a/src/common.sh
+++ b/src/common.sh
@@ -185,14 +185,6 @@ function cleanup() {
     # make sure that all child processed die when we die
     local pids=$(jobs -pr)
     [ -n "$pids" ] && kill $pids && sleep 5 && kill -9 $pids
-    exit 0
-}
-
-function cleanup() {
-    # make sure that all child processed die when we die
-    local pids=$(jobs -pr)
-    [ -n "$pids" ] && kill $pids
-    exit 0
 }
 
 function install_fail_on_error_trap() {

--- a/src/custompios
+++ b/src/custompios
@@ -32,7 +32,7 @@ mkdir -p $BASE_WORKSPACE
 mkdir -p $BASE_MOUNT_PATH
 
 install_cleanup_trap
-install_fail_on_error_trap $BASE_MOUNT_PATH
+install_fail_on_error_trap
 unmount_image $BASE_MOUNT_PATH force || true
 
 pushd $BASE_WORKSPACE
@@ -126,3 +126,4 @@ pushd $BASE_WORKSPACE
   fi
 popd
 
+echo_green -e "\nBUILD SUCCEEDED!\n"

--- a/src/custompios
+++ b/src/custompios
@@ -3,13 +3,15 @@
 # This script takes a Raspbian image and adds to it octoprint and verions addons
 # Written by Guy Sheffer <guysoft at gmail dot com>
 # GPL V3
+set -e
+
 export LC_ALL=C
 
 source ${CUSTOM_PI_OS_PATH}/common.sh
 
 function execute_chroot_script() {
   #move OctoPi filesystem files
-  cp -vr --preserve=mode,timestamps $1/filesystem .
+  cp -vr --preserve=mode,timestamps $1/filesystem . || true
 
   #black magic of qemu-arm-static
   cp `which qemu-arm-static` usr/bin
@@ -23,7 +25,7 @@ function execute_chroot_script() {
   
   #cleanup
   rm chroot_script
-  rm -rfv filesystem
+  rm -rfv filesystem || true
 }
 
 mkdir -p $BASE_WORKSPACE

--- a/src/execution_order.py
+++ b/src/execution_order.py
@@ -64,6 +64,7 @@ if __name__ == "__main__":
     with open(args.output_script, "w+") as f:
         f.write("#!/usr/bin/env bash\n")
         f.write("set -x\n")
+        f.write("set -e\n")
         parse(args.modules.replace(" ", ""), lambda module, state: handle(module, state, f))
         
     os.chmod(args.output_script, 0o755)

--- a/src/modules/base/end_chroot_script
+++ b/src/modules/base/end_chroot_script
@@ -4,6 +4,8 @@
 # Written by Guy Sheffer <guysoft at gmail dot com>
 # GPL V3
 ########
+set -ex
+
 if [ -n "$BASE_APT_PROXY" ]
 then
   rm -r /etc/apt/apt.conf.d/02octopi_build_proxy

--- a/src/modules/disable-services/end_chroot_script
+++ b/src/modules/disable-services/end_chroot_script
@@ -4,4 +4,6 @@
 # Written by Guy Sheffer <guysoft at gmail dot com> and Gina Häußge <osd@foosel.net>
 # GPL V3
 ########
+set -ex 
+
 rm -r /usr/sbin/policy-rc.d 

--- a/src/modules/disable-services/start_chroot_script
+++ b/src/modules/disable-services/start_chroot_script
@@ -4,6 +4,7 @@
 # Written by Guy Sheffer <guysoft at gmail dot com> and Gina Häußge <osd@foosel.net>
 # GPL V3
 ########
+set -ex
 
 source /common.sh
 install_cleanup_trap

--- a/src/modules/ffmpeg/end_chroot_script
+++ b/src/modules/ffmpeg/end_chroot_script
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -ex
+
 if [ "$FFMPEG_CLEANUP" == "yes" ]
     then
     echo "cleaning up ffmpeg"

--- a/src/modules/ffmpeg/start_chroot_script
+++ b/src/modules/ffmpeg/start_chroot_script
@@ -4,6 +4,7 @@
 # Written by Guy Sheffer <guysoft at gmail dot com>
 # GPL V3
 ########
+set -ex
 
 source /common.sh
 install_cleanup_trap

--- a/src/modules/kernel/end_chroot_script
+++ b/src/modules/kernel/end_chroot_script
@@ -6,6 +6,7 @@
 ########
 
 set -x
+set -e
 
 # Source error handling, leave this in place
 source /common.sh

--- a/src/modules/kernel/start_chroot_script
+++ b/src/modules/kernel/start_chroot_script
@@ -6,6 +6,7 @@
 ########
 
 set -x
+set -e
 
 # Source error handling, leave this in place
 source /common.sh

--- a/src/modules/password-for-sudo/start_chroot_script
+++ b/src/modules/password-for-sudo/start_chroot_script
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 # password-for-sudo
 #
 # Reverts Raspbian's default of allowing sudo to be always invoked without having to
@@ -8,6 +7,8 @@
 # Written by Gina Häußge <gina@octoprint.org>
 # GPL V3
 ########
+
+set -ex
 
 source /common.sh
 install_cleanup_trap


### PR DESCRIPTION
This fixes error detection during build (see #18). All scripts were adjusted to `set -e` and an error trap was installed that when triggered unmounts the image and logs "BUILD FAILED" to console. I also added a "BUILD SUCCEEDED" message.

This has so far only been tested against the OctoPi build - it might be that in the scripts not needed for that there are still lines that can fail without any issues (e.g. trying to delete non existing files) and that need a `|| true` appended, just like it was necessary in `execute_chroot_script`.

I also had to add a `cd $DIST_PATH` into the `ERR` trap before the unmount, otherwise depending on the  location in the script the error happened the mount point would be blocked by the script itself and the forced `kill` before the unmount would thus kill the script itself. Since we should be in a subshell at this point if I'm not mistaken I think that shouldn't cause any issues at all though.

I tested the error case with a custom module `always_fail` that I added to my local install. If there's interest I can also send a PR for that, it makes testing things like this so much easier.