### PR TITLE
First draft at Docker build script

### DIFF
--- a/src/build_docker
+++ b/src/build_docker
@@ -1,0 +1,4 @@
+
+# Build the docker images that are used to build the CustomPiOS images
+
+docker build --no-cache=true --force-rm=true --tag=custom_pios -f docker/Dockerfile docker

--- a/src/custompios
+++ b/src/custompios
@@ -10,6 +10,12 @@ export LC_ALL=C
 source ${CUSTOM_PI_OS_PATH}/common.sh
 
 function execute_chroot_script() {
+
+  # In docker, these extra commands are required to enable this black-magic
+  if [ -f /.dockerenv ]; then
+    update-binfmts --enable qemu-arm
+    mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc || true
+  fi
   #move OctoPi filesystem files
   cp -vr --preserve=mode,timestamps $1/filesystem . || true
 

--- a/src/dist_generators/dist_example/src/docker/README.md
+++ b/src/dist_generators/dist_example/src/docker/README.md
@@ -1,14 +1,14 @@
-Custom Pi OS with Docker
+CustomPiOS with Docker
 ========================
 
-Building a custom pi os within a docker environement will mean fewer changes to your host OS.
+Building a CustomPiOS within a docker environement will mean fewer changes to your host OS.
 
 Creating the Docker image
 -------------------------
-Before building with Docker, you must build the custom_pios image.
+Before building with Docker, you must build the CustomPiOS image.
 
 ```
-cd <custom pios folder>/src
+cd <CustomPiOS folder>/src
 ./build_docker
 ```
 
@@ -18,4 +18,4 @@ is a good way to determine if it's configured for your use.
 
 Building
 --------
-After you have the custom_pios image, you can execute run_docker_build.sh to build a custom pi os.
+After you have the CustomPiOS image, you can execute run_docker_build.sh to build a CustomPiOS.

--- a/src/dist_generators/dist_example/src/docker/README.md
+++ b/src/dist_generators/dist_example/src/docker/README.md
@@ -1,0 +1,21 @@
+Custom Pi OS with Docker
+========================
+
+Building a custom pi os within a docker environement will mean fewer changes to your host OS.
+
+Creating the Docker image
+-------------------------
+Before building with Docker, you must build the custom_pios image.
+
+```
+cd <custom pios folder>/src
+./build_docker
+```
+
+If you are told docker isn't running, make sure you have docker set up properly. You will need
+docker running, and you will need to be in the `docker` group, or run with sudo. Running `docker ps`
+is a good way to determine if it's configured for your use.
+
+Building
+--------
+After you have the custom_pios image, you can execute run_docker_build.sh to build a custom pi os.

--- a/src/dist_generators/dist_example/src/docker/run_docker_build.sh
+++ b/src/dist_generators/dist_example/src/docker/run_docker_build.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+
+DIST_PATH=${DIR}
+CUSTOM_PI_OS_PATH=$(<${DIR}/custompios_path)
+
+# make all the loop devices available in the container.
+DEVICE_FLAGS=$(for loop in /dev/loop*; do echo -n "--device $loop "; done)
+
+# -v mounts a folder in the container host_path:container_path
+# -w sets the working directory
+# --cap-add adds linux capabilities (see man 7 capabilities)
+# -it makes the container interactive (so we see what it's doing)
+# --name gives the container a name (which makes deleting it easier)
+# --rm removes it after we've built with it.
+# custom_pios is the name of the image to start with
+# the rest is the command to run.
+docker run \
+  -v $DIST_PATH:/src \
+  -w /src \
+  -v $CUSTOM_PI_OS_PATH:$CUSTOM_PI_OS_PATH \
+  --cap-add=SYS_ADMIN \
+  $DEVICE_FLAGS \
+  -it \
+  --name=build_dist \
+  --rm \
+  custom_pios \
+  ./build_dist $@
+

--- a/src/dist_generators/dist_example/src/docker/run_docker_build.sh
+++ b/src/dist_generators/dist_example/src/docker/run_docker_build.sh
@@ -4,6 +4,12 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 DIST_PATH=${DIR}
 CUSTOM_PI_OS_PATH=$(<${DIR}/custompios_path)
 
+# if there are no loop devices, then let's make sure we have loop modprobed
+if [ ! -f /dev/loop0 ]; then
+    echo "We need loop to mount the images. 'Running modprobe loop'"
+    sudo modprobe loop
+fi
+
 # make all the loop devices available in the container.
 DEVICE_FLAGS=$(for loop in /dev/loop*; do echo -n "--device $loop "; done)
 

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -1,0 +1,21 @@
+
+FROM debian:stretch
+
+MAINTAINER jeffeb3
+
+RUN set -x \
+    && apt-get update && apt-get install -y \
+        build-essential \
+        curl \
+        git \
+        wget \
+        realpath \
+        p7zip-full \
+        python3 \
+        binfmt-support \
+        qemu \
+        qemu-user-static \
+        sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
This looks about right to me. I think you should be able to build the docker image once, and put the dist_example/docker folder in any of your other repos, and the run_docker.sh should pick up the custompios_path the same way you were doing it.

Access to /dev/loop* and CAP_SYS_ADMIN seem pretty important, but I did manage to remove the --privileged=true.

I am PR'ing this against the CustomPiOS branch, but I'm not sure if you'd prefer the devel branch?