### PR TITLE
Fix regex bug in enabling compositing

### DIFF
--- a/src/modules/gui/filesystem/home/pi/scripts/enable_gpu
+++ b/src/modules/gui/filesystem/home/pi/scripts/enable_gpu
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [ ! -f /etc/gpu_enabled ]; then
-    sudo sed 's@matchbox-window-manager \&@compton --backend glx --unredir-if-possible --glx-swap-method buffer-age --glx-no-stencil --paint-on-overlay --vsync opengl &\nmatchbox-window-manager \&@g' -i /home/pi/scripts/start_gui
+    sudo sed 's@matchbox-window-manager \&@compton -b -d :0 --backend glx --unredir-if-possible --glx-swap-method buffer-age --glx-no-stencil --paint-on-overlay --vsync opengl \nmatchbox-window-manager \&@g' -i /home/pi/scripts/start_gui
     sudo sed -i /boot/cmdline.txt -e "s/ quiet//"
     sudo sed -i /boot/cmdline.txt -e "s/ splash//"
     sudo sed -i /boot/cmdline.txt -e "s/ plymouth.ignore-serial-consoles//"


### PR DESCRIPTION
This bug caused matchbox to be started twice, due to an unescaped &, causing a second instance to start needlessly.

I also set compton to background mode and multi-monitor, so it will work in more conditions.

Fixes "Video Decode: Unavailable" in Chromium due to "Compositing manager: No".

To confirm this patch, you can do the following:
1. Replicate old situation:
```
sed 's@matchbox-window-manager \&@compton --backend glx --unredir-if-possible --glx-swap-method buffer-age --glx-no-stencil --paint-on-overlay --vsync opengl &\nmatchbox-window-manager \&@g' -i start_gui
```
Result:
```
[...]
compton --backend glx --unredir-if-possible --glx-swap-method buffer-age --glx-no-stencil --paint-on-overlay --vsync opengl matchbox-window-manager &
matchbox-window-manager &
[...]
```
Notice the duplicate matchbox-windows-manager & entry.

2. Try the new regexp
```
sed 's@matchbox-window-manager \&@compton -b -d :0 --backend glx --unredir-if-possible --glx-swap-method buffer-age --glx-no-stencil --paint-on-overlay --vsync opengl \nmatchbox-window-manager \&@g' -i start_gui
```
Result:
```
[...]
compton -b -d :0 --backend glx --unredir-if-possible --glx-swap-method buffer-age --glx-no-stencil --paint-on-overlay --vsync opengl 
matchbox-window-manager &
[...]
```

Notice that there is no longer a duplicate entry for matchbox.