### PR TITLE
Hardware accelerated FFmpeg build

### DIFF
--- a/src/modules/ffmpeg/start_chroot_script
+++ b/src/modules/ffmpeg/start_chroot_script
@@ -22,7 +22,7 @@ pushd /usr/src
     
     git clone https://github.com/FFmpeg/FFmpeg.git
     pushd FFmpeg
-        ./configure --arch=armel --target-os=linux --enable-gpl --enable-libx264 --enable-nonfree
+        ./configure --arch=armel --target-os=linux --enable-gpl --enable-libx264 --enable-nonfree  --enable-mmal --enable-omx --enable-omx-rpi
         make -j 2
         checkinstall -y --fstrans=no
     popd


### PR DESCRIPTION
Added additional switches to configure FFmpeg build for GPU-accelerated x264.

Original build instructions appear to be taken from http://www.jeffreythompson.org/blog/2014/11/13/installing-ffmpeg-for-raspberry-pi/

A newer setup is at https://www.reddit.com/r/raspberry_pi/comments/5677qw/hardware_accelerated_x264_encoding_with_ffmpeg/
