### PR TITLE
pre_chroot_script: use public nameservers

### DIFF
--- a/src/variants/armbian/pre_chroot_script
+++ b/src/variants/armbian/pre_chroot_script
@@ -11,7 +11,9 @@ install_cleanup_trap
 unpack /filesystem/root /
 
 mv /etc/resolv.conf /etc/resolv.conf.orig || true
-echo "nameserver 213.73.91.35" > /etc/resolv.conf
+echo "nameserver 8.8.8.8" > /etc/resolv.conf
+echo "nameserver 8.8.4.4" >> /etc/resolv.conf
+echo "nameserver 1.1.1.1" >> /etc/resolv.conf
 
 echo "" > /dev/null
 


### PR DESCRIPTION
The DNS server that was originally referenced is a (seemingly) random IP that happened to be a DNS server?

I've chosen the Google and Cloudflare public DNS servers for the sake of simplicity. 