### PR TITLE
Cockpit

### DIFF
--- a/src/modules/cockpit-install/config
+++ b/src/modules/cockpit-install/config
@@ -1,0 +1,7 @@
+##########################################################
+# Cockpit is a Red Hat sponsored free software project released under the LGPL v2.1+
+# https://cockpit-project.org/
+
+#disable the cockpit web socket if you already have a cockpit server setup and dont want this
+#pi to have a web dashboard
+CUSTOMPIOS_DISABLE_COCKPIT_SOCKET=no

--- a/src/modules/cockpit-install/filesystem/home/pi/scripts/install_cockpit
+++ b/src/modules/cockpit-install/filesystem/home/pi/scripts/install_cockpit
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ ! -f /etc/cockpit_service ]; then
+    apt-get install -y cockpit
+    touch /etc/cockpit_service
+    if [ "$CUSTOMPIOS_DISABLE_COCKPIT_SOCKET" == "yes" ]; then
+        systemctl disable cockpit.socket
+    fi
+fi

--- a/src/modules/cockpit-install/filesystem/root_init/etc/systemd/system/cockpit_installer.service
+++ b/src/modules/cockpit-install/filesystem/root_init/etc/systemd/system/cockpit_installer.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=On first boot run Cockpit installer
+After=network.target
+After=systemd-user-sessions.service
+After=network-online.target
+[Service]
+User=root
+ExecStart=/home/pi/scripts/install_cockpit
+ExecStop=
+[Install]
+WantedBy=multi-user.target

--- a/src/modules/cockpit-install/start_chroot_script
+++ b/src/modules/cockpit-install/start_chroot_script
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# CustomPiOS generation script
+# Helper script that runs in a Raspbian chroot to create the CustomPiOS distro gui module
+# Written by asdfinit
+# GPL V3
+
+set -x
+set -e
+
+source /common.sh
+
+unpack /filesystem/home/pi /home/pi pi
+unpack /filesystem/root_init /
+
+chmod +x /home/pi/scripts/install_cockpit
+systemctl enable cockpit_installer.service


### PR DESCRIPTION
Cockpit is a Red Hat sponsored free software project released under the LGPL v2.1+
https://cockpit-project.org/

Optional package for installing Cockpit after first boot. It can't be installed during the build so this will get it up and running. This makes it easy to manage multiple pi's from a single dashboard.