### PR TITLE
Autoclean instead of clean, fix bug with unpacking(Fix #63 and #64)

### DIFF
--- a/src/common.sh
+++ b/src/common.sh
@@ -125,15 +125,20 @@ function unpack() {
   then
     owner=$3
   fi
-
+  mkdir -p /tmp/unpack/
   # $from/. may look funny, but does exactly what we want, copy _contents_
   # from $from to $to, but not $from itself, without the need to glob -- see 
   # http://stackoverflow.com/a/4645159/2028598
-  cp -v -r --preserve=mode,timestamps $from/. $to
+  cp -v -r --preserve=mode,timestamps $from/. /tmp/unpack/
+  
   if [ -n "$owner" ]
   then
-    chown -hR $owner:$owner $to
+    chown -hR $owner:$owner /tmp/unpack/
   fi
+
+  cp -v -r --preserve=mode,ownership,timestamps /tmp/unpack/. $to
+  rm -r /tmp/unpack
+
 }
 
 function detach_all_loopback(){

--- a/src/variants/armbian/pre_chroot_script
+++ b/src/variants/armbian/pre_chroot_script
@@ -40,7 +40,7 @@ yes 1234 | passwd
 
 #cleanup
 mkdir -p /var/cache/apt/archives
-apt-get clean
+apt-get autoclean
 apt-get update --allow-releaseinfo-change
 apt-get -y --force-yes install avahi-daemon || true
 apt-get -y --force-yes install python python-distutils-extra || true

--- a/src/variants/armbian/pre_chroot_script
+++ b/src/variants/armbian/pre_chroot_script
@@ -40,7 +40,11 @@ yes 1234 | passwd
 
 #cleanup
 mkdir -p /var/cache/apt/archives
-apt-get autoclean
+if [ -n "$BASE_APT_CACHE" ] && [ "$BASE_APT_CACHE" != "no" ]; then
+  apt-get autoclean
+else
+  apt-get clean
+fi
 apt-get update --allow-releaseinfo-change
 apt-get -y --force-yes install avahi-daemon || true
 apt-get -y --force-yes install python python-distutils-extra || true

--- a/src/variants/bananapi-m1/pre_chroot_script
+++ b/src/variants/bananapi-m1/pre_chroot_script
@@ -9,4 +9,8 @@ unpack /filesystem/root /
 
 #cleanup
 mkdir -p /var/cache/apt/archives
-apt-get autoclean
+if [ -n "$BASE_APT_CACHE" ] && [ "$BASE_APT_CACHE" != "no" ]; then
+  apt-get autoclean
+else
+  apt-get clean
+fi

--- a/src/variants/bananapi-m1/pre_chroot_script
+++ b/src/variants/bananapi-m1/pre_chroot_script
@@ -9,4 +9,4 @@ unpack /filesystem/root /
 
 #cleanup
 mkdir -p /var/cache/apt/archives
-apt-get clean
+apt-get autoclean

--- a/src/variants/example/post_chroot_script
+++ b/src/variants/example/post_chroot_script
@@ -8,4 +8,8 @@ install_chroot_fail_on_error_trap
 unpack /filesystem/root /
 
 #cleanup
-apt-get clean
+if [ -n "$BASE_APT_CACHE" ] && [ "$BASE_APT_CACHE" != "no" ]; then
+  apt-get autoclean
+else
+  apt-get clean
+fi


### PR DESCRIPTION
Fixes bugs:

#63 : unpack would chown the enture target dir with all existing files, and 
#64 : apt-get clean would delete cached files that are still usable, eliminating caching between builds.

My simple solution for copying files involves unnecessary disk activity, but I think the bug is big enough to warrant fixing sooner rather than later, and then refining as time allows.