### PR TITLE
Update moved x264 source URL in FFMPEG module

### DIFF
--- a/src/modules/ffmpeg/start_chroot_script
+++ b/src/modules/ffmpeg/start_chroot_script
@@ -13,7 +13,7 @@ apt-get update
 apt-get install -y checkinstall git
 
 pushd /usr/src
-    git clone git://git.videolan.org/x264
+    git clone https://code.videolan.org/videolan/x264.git
     pushd x264
         ./configure --host=arm-unknown-linux-gnueabi --enable-static --disable-opencl
         make -j 2


### PR DESCRIPTION
This is a single issue PR.

VLC source management moved to GitLab and changed URLs at some point, per details here: http://git.videolan.org.

Trying to build a CustomPiOS distro with the ffmpeg module results in persistent failure when sourcing x264 to build. This PR just updates the new source target.

Building FFMPEG module ran successfully on Ubuntu 18.04 x86_64.

Thanks!