### PR TITLE
Dockerfile for arm64v8

### DIFF
--- a/src/Dockerfile.arm64v8
+++ b/src/Dockerfile.arm64v8
@@ -1,0 +1,41 @@
+FROM debian:buster AS builder
+
+# Download QEMU, see https://github.com/docker/hub-feedback/issues/1261
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    apt-utils \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt -qyy clean
+RUN export QEMU_USER_STATIC_LATEST_TAG=$(curl -s https://api.github.com/repos/multiarch/qemu-user-static/tags \
+        | grep 'name.*v[0-9]' | head -n 1 | cut -d '"' -f 4) && \
+    curl -SL "https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_USER_STATIC_LATEST_TAG}/x86_64_qemu-aarch64-static.tar.gz" \
+        | tar xzv --directory /
+
+FROM arm64v8/debian
+
+COPY --from=builder /qemu-arm-static /usr/bin/
+
+MAINTAINER Guy Sheffer <guysoft at gmail dot com>
+
+RUN set -x \
+    && apt-get update && apt-get install -y \
+        build-essential \
+        curl \
+        git \
+        wget \
+        p7zip-full \
+        python3 \
+        binfmt-support \
+        qemu \
+        sudo \
+        zip \
+        lsof \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN ln -s /CustomPiOS/nightly_build_scripts/custompios_nightly_build /usr/bin/build
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+COPY . /CustomPiOS
+
+CMD ["/bin/bash"]

--- a/src/Dockerfile.arm64v8
+++ b/src/Dockerfile.arm64v8
@@ -16,7 +16,7 @@ FROM arm64v8/debian
 
 COPY --from=builder /qemu-aarch64-static /usr/bin/
 
-MAINTAINER Guy Sheffer <guysoft at gmail dot com>
+LABEL maintainer="Guy Sheffer <guysoft at gmail dot com>"
 
 RUN set -x \
     && apt-get update && apt-get install -y \

--- a/src/Dockerfile.arm64v8
+++ b/src/Dockerfile.arm64v8
@@ -14,7 +14,7 @@ RUN export QEMU_USER_STATIC_LATEST_TAG=$(curl -s https://api.github.com/repos/mu
 
 FROM arm64v8/debian
 
-COPY --from=builder /qemu-arm-static /usr/bin/
+COPY --from=builder /qemu-aarch64-static /usr/bin/
 
 MAINTAINER Guy Sheffer <guysoft at gmail dot com>
 

--- a/src/Dockerfile.arm64v8
+++ b/src/Dockerfile.arm64v8
@@ -28,7 +28,6 @@ RUN set -x \
         python3 \
         binfmt-support \
         qemu \
-        qemu-user-static \
         sudo \
         zip \
         lsof \

--- a/src/Dockerfile.arm64v8
+++ b/src/Dockerfile.arm64v8
@@ -28,6 +28,7 @@ RUN set -x \
         python3 \
         binfmt-support \
         qemu \
+        qemu-user-static \
         sudo \
         zip \
         lsof \


### PR DESCRIPTION
Created arm64v8 Dockerfile using arm32 one as base.

It was tested under MacOS BigSur on M1 cpu with Docker Desktop 2020-12-16 preview.
Works well without qemu emulation both for building armhf and arm64 images.
OctoPi build takes 10 minutes for armhf variant and 7 minutes for arm64.