### PR TITLE
Allow altering pi account

### DIFF
--- a/src/modules/admin-toolkit/config
+++ b/src/modules/admin-toolkit/config
@@ -13,10 +13,15 @@
 ######### User Required Section ###########################
 #
 #  Adding another user requires at least a username.
+#  If the user already exists, it will not be recreated,
+#  but the password and ssh keys will be changed.
 #  A home folder will be created.
 #  The default profile will be set to bash.
 #  Default password is raspberry. PLEASE CHANGE THIS. 
 #  User will be added to the sudo and adm group. 
+#
+#  If the user specified is not pi, pi's password will be
+#  set to a randomly generated string.
 #
 ###########################################################
 

--- a/src/modules/admin-toolkit/start_chroot_script
+++ b/src/modules/admin-toolkit/start_chroot_script
@@ -18,22 +18,26 @@ install_cleanup_trap
 if [ "$ADMIN_TOOLKIT_NAME" != "default" ]
 then
 
-    # add user
+    # add user if it doesn't already exist
     if [ "$ADMIN_TOOLKIT_FULLNAME" != "default" ]
     then
         echo "Adding user $ADMIN_TOOLKIT_NAME with GECOS fields"
-        useradd -m -s $(which bash) -G sudo,adm "${ADMIN_TOOLKIT_NAME}" -c "${ADMIN_TOOLKIT_FULLNAME}"
+        id "${ADMIN_TOOLKIT_NAME}" || useradd -m -s $(which bash) -G sudo,adm "${ADMIN_TOOLKIT_NAME}" -c "${ADMIN_TOOLKIT_FULLNAME}"
     else
         echo "Adding user $ADMIN_TOOLKIT_NAME"
-        useradd -m -s $(which bash) -G sudo,adm "${ADMIN_TOOLKIT_NAME}"
+        id "${ADMIN_TOOLKIT_NAME}" || useradd -m -s $(which bash) -G sudo,adm "${ADMIN_TOOLKIT_NAME}"
     fi
 
     # check for override password
     if [ "$ADMIN_TOOLKIT_PASSWORD" != "default" ]
     then
         echo "${ADMIN_TOOLKIT_NAME}:${ADMIN_TOOLKIT_PASSWORD}" | chpasswd
-        RANDOM_PW=$(date +%s | sha256sum | base64 | head -c 32)
-        echo "pi:${RANDOM_PW}" | chpasswd
+        # if creating a user other than 'pi', set pi's password to a random string
+        if [ "${ADMIN_TOOLKIT_NAME}" != "pi" ]
+        then
+            RANDOM_PW=$(date +%s | sha256sum | base64 | head -c 32)
+            echo "pi:${RANDOM_PW}" | chpasswd
+        fi
     else
         echo "${ADMIN_TOOLKIT_NAME}:raspberry" | chpasswd
     fi


### PR DESCRIPTION
Use id to see if the account specified already exists. If it does, skip creating it but still change the password and setup SSH keys.
This allows the module to be used to secure the pi account without having to create a new account.

Tested on one of my builds, and it changed the password and added my SSH keys perfectly.  This should only change the behaviour if you specify `ADMIN_TOOLKITNAME=pi`, which previously would cause the build to just die at the `useradd`, so it shouldn't affect any existing builds using the module.

Fixes #104 