### PR TITLE
Shorthand function to modify /boot/config.txt

### DIFF
--- a/src/common.sh
+++ b/src/common.sh
@@ -461,3 +461,8 @@ function copy_and_export_folder(){
   cp -va $@ | awk -F  "' -> '"  '{print substr($2, 1, length($2)-1)}' | xargs -d"\n" -t bash -x -c 'custompios_export '${OUTPUT}' "$@"' _
 }
 
+function set_config_var() {
+  # Set a value for a specific variable in /boot/config.txt
+  # See https://github.com/RPi-Distro/raspi-config/blob/master/raspi-config#L231
+  raspi-config nonint set_config_var $1 $2 /boot/config.txt
+}


### PR DESCRIPTION
I am currently using this shorthand to modify / add values into `/boot/config.txt`

It does rely on `raspi-config` to get the job done. I chose to go with `raspi-config` as it gets maintained to work with the newer RPi versions, and it either uncomments the relevant config line or it appends a line "intelligently". This can replace the usual `sed` commands

Obviously, it only works if the image is RaspiOS / Raspbian, otherwise it'd be missing `raspi-config`