### PR TITLE
Added push of SHA256 tag when pushing develop

### DIFF
--- a/src/hooks/post_push
+++ b/src/hooks/post_push
@@ -44,24 +44,26 @@ function docker_tag_exists() {
 # ${IMAGE_NAME} = index.docker.io/guysoft/custompios-test:1.2.4-amd64
 # ${DOCKER_TAG} = 1.2.4-amd64
 
+REPO_NAME=${IMAGE_NAME##*/} ; REPO_NAME=${REPO_NAME%%:*}
+REPO_NAME_AND_USER=${IMAGE_NAME%%/${REPO_NAME}*}
+USER_NAME=${REPO_NAME_AND_USER##*/}
+  
+NAME=${USER_NAME}/${REPO_NAME}
 
 # If we're building the "devel" branch, then also push it as "latest"
 if [[ "$DOCKER_TAG" == "amd64" ]] || [[ "$DOCKER_TAG" == "arm32v7" ]] || [[ "$DOCKER_TAG" == "arm64v8" ]]
 then
   echo "Pushing multi-arch manifest $DOCKER_REPO:latest"
   ./manifest-tool push from-spec multi-arch-manifest.yaml
-
+  # If we're building the "devel" branch, then also push a "sha-XXXX" tag for better version management
+  generate_manifest "${NAME}" $(git rev-parse HEAD)
+  ./manifest-tool push from-spec manifest-generated.yaml
+  
 # Handle release
 else
   echo "handeling: ${DOCKER_REPO}|${IMAGE_NAME}|${DOCKER_TAG}"
   
   RELEASE_TAG=${DOCKER_TAG%%-*}
-  
-  REPO_NAME=${IMAGE_NAME##*/} ; REPO_NAME=${REPO_NAME%%:*}
-  REPO_NAME_AND_USER=${IMAGE_NAME%%/${REPO_NAME}*}
-  USER_NAME=${REPO_NAME_AND_USER##*/}
-  
-  NAME=${USER_NAME}/${REPO_NAME}
   
   # Example: values
   # ${NAME} = guysoft/custompios


### PR DESCRIPTION
This pull request tries to address one of the issues that happened to me. When the CMake build broke (https://github.com/guysoft/CustomPiOS/issues/120) I had some days where I was blocked from making a build, because I updated the local `devel` image.
To overcome this issue, and having a more reliable build, I think it would be good to push also an `SHA-XXXXXX` tag, each time we push the `devel` image. 

Using this approach, when a new `devel` tag is pushed, the old one still remains around and can be pointed to in build processes that require a reliable configuration.

I had no way of testing this, please provide feedback, I'll be happy to keep helping to move this forward.