### PR TITLE
Add docker tags and label

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,9 +3,9 @@ name: ci
 on:
   push:
     branches:
-      - 'master'
-      - 'devel'
-      - 'docker-github-actions'
+      - "master"
+      - "devel"
+      - "docker-github-actions"
 
 jobs:
   docker:
@@ -18,11 +18,18 @@ jobs:
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       -
+        name: Docker meta tag
+        id: docker_meta
+        uses: docker/metadata-action@v3.5.0
+        with:
+          images: guysoft/custompios
+          tag-sha: true
+      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       -
         name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -35,6 +42,7 @@ jobs:
           file: src/Dockerfile
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
-          tags: guysoft/custompios:devel
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
           secrets: |
             GIT_AUTH_TOKEN=${{ secrets.MY_GITHUB_TOKEN }}


### PR DESCRIPTION
Tries to solve https://github.com/guysoft/CustomPiOS/issues/140. By default this action adds the tag of the current branch and also add the `latest` tag to the latest image pushed.

It should also add the commit sha as a tag, useful to get a specific commit image (in case of regression, etc).
Try and see if it can work for the project. Otherwise we can customize tags using the rules here https://github.com/docker/metadata-action#usage.

I tried on my end by logging out the output and all seems to be working fine.