### PR TITLE
Added two 'QoL' functions to common.sh

### DIFF
--- a/src/common.sh
+++ b/src/common.sh
@@ -398,6 +398,20 @@ function minimize_ext() {
   fi
 }
 
+# Skip apt update if Cache not older than 1 Hour.
+function apt_update_skip() {
+    if [ -f "/var/cache/apt/pkgcache.bin" ] && \
+    [ "$(($(date +%s)-$(stat -c %Y /var/cache/apt/pkgcache.bin)))" -lt "3600" ];
+    then
+        echo_green "APT Cache needs no update! [SKIPPED]"
+    else
+        # force update
+        echo_red "APT Cache needs to be updated!"
+        echo_green "Running 'apt update' ..."
+        apt update
+    fi
+}
+
 function is_installed(){
   # checks if a package is installed, returns 1 if installed and 0 if not.
   # usage: is_installed <package_name>
@@ -411,6 +425,30 @@ function is_in_apt(){
     echo 1
   else
     echo 0
+  fi
+}
+
+### Only install Packages if not installed.
+##  check_install_pkgs $MODULNAME_PKGS_VAR (Replace with your Variable set in config file)
+function check_install_pkgs() {
+  ## Build Array from Var
+  local missing_pkgs
+  for dep in "$@"; do
+    # if in apt cache and not installed add to array
+    if [ $(is_in_apt ${dep}) -eq 1 ] && [ $(is_installed ${dep}) -ne 1 ]; then
+      missing_pkgs+="${dep}"
+    else
+    # if not in apt cache
+      echo_red "Missing Package ${dep} not found in Apt Repository. [SKIPPED]"
+    fi 
+  done
+  # if missing pkgs install missing else skip that.
+  if [ "${#missing_pkgs[@]}" -ne 0 ]; then
+      echo_red "${#missing_pkgs[@]} missing Packages..."
+      echo_green "Installing ${missing_pkgs[@]}"
+      apt install --yes "${missing_pkgs[@]}"
+  else
+      echo_green "No Dependencies missing... [SKIPPED]"
   fi
 }
 

--- a/src/common.sh
+++ b/src/common.sh
@@ -436,7 +436,7 @@ function check_install_pkgs() {
   for dep in "$@"; do
     # if in apt cache and not installed add to array
     if [ $(is_in_apt ${dep}) -eq 1 ] && [ $(is_installed ${dep}) -ne 1 ]; then
-      missing_pkgs+="${dep}"
+      missing_pkgs+=("${dep}")
     else
     # if not in apt cache
       echo_red "Missing Package ${dep} not found in Apt Repository. [SKIPPED]"


### PR DESCRIPTION
* check_install_pkgs - check if pkgs is installed if not installs it.
* apt_update_skip - Skips 'apt update' if cache not older than one Hour

check_install_pkgs accepts multiple words in Variable.
As example:
Your module needs many dependencies.
Place an Variable in your config file like:
[ -n "$KLIPPER_DEPS" ] || KLIPPER_DEPS="wget git gpiod \
virtualenv python-dev \
libffi-dev build-essential \
libncurses-dev libusb-dev \
avrdude gcc-avr binutils-avr avr-libc \
stm32flash dfu-util libnewlib-arm-none-eabi \
gcc-arm-none-eabi binutils-arm-none-eabi libusb-1.0-0"

in your start_chroot_script, you can use:

apt_update_skip
check_install_pkgs $KLIPPER_DEPS

This will check your apt cache is present and if, then its time since last 'apt update'
If it is older than 1 Hour it will run 'apt update'
After that it checks for your set Packages if is one or more missing it will install them.

This could be Handy if you use multiple Modules with similar Dependencies.

Regards
