### PR TITLE
Allow power management to be disabled and screen rotated

### DIFF
--- a/src/modules/gui/filesystem/home/pi/scripts/start_gui
+++ b/src/modules/gui/filesystem/home/pi/scripts/start_gui
@@ -1,7 +1,22 @@
 #!/bin/bash
-xset s off         # don't activate screensaver
-xset -dpms         # disable DPMS (Energy Star) features.
-xset s noblank     # don't blank the video device
+
+# Stop the screen from turning off when idle.
+DISABLE_POWER_MANAGEMENT=yes
+
+# Rotate screen if needed, see 'xrandr -h' for options.
+DISPLAY_ORIENTATION=normal
+
+if ["${DISPLAY_ORIENTATION}" != 'normal'];
+then
+  xrandr --orientation ${DISPLAY_ORIENTATION}
+fi
+
+if ["${DISABLE_POWER_MANAGEMENT}" == 'yes'];
+then
+  xset s off         # don't activate screensaver
+  xset -dpms         # disable DPMS (Energy Star) features.
+  xset s noblank     # don't blank the video device
+fi
 
 matchbox-window-manager &
 


### PR DESCRIPTION
Adds options to turn off the disabling power management and rotate the screen if required.

Depending the the use case of the OS it may be desirable to keep the standard power management options for Xorg so that the screen will blank when the input is idle for an amount of time. For example this will mean that the screen will blank until a touchscreen is touched.

Depending on the screen used, it can be rotated at an Xorg level also in the start_gui script. For my use case this is required when using a non official raspberry pi 10" touch screen in the standard case. (Official touch screens use an option in `/boot/config.txt`).