### PR TITLE
Fix broken runtime options

### DIFF
--- a/src/modules/gui/filesystem/home/pi/scripts/start_gui
+++ b/src/modules/gui/filesystem/home/pi/scripts/start_gui
@@ -6,12 +6,12 @@ DISABLE_POWER_MANAGEMENT=yes
 # Rotate screen if needed, see 'xrandr -h' for options.
 DISPLAY_ORIENTATION=normal
 
-if ["${DISPLAY_ORIENTATION}" != 'normal'];
+if [[ "${DISPLAY_ORIENTATION}" != 'normal' ]];
 then
   xrandr --orientation ${DISPLAY_ORIENTATION}
 fi
 
-if ["${DISABLE_POWER_MANAGEMENT}" == 'yes'];
+if [[ "${DISABLE_POWER_MANAGEMENT}" == 'yes' ]];
 then
   xset s off         # don't activate screensaver
   xset -dpms         # disable DPMS (Energy Star) features.


### PR DESCRIPTION
MR #157 broke disabling screen blanking. It has missing spaces after the [ and before the ].

I fix those and also changed [] to [[]] as it  can handle more complex conditions and is less error-prone.

I encountered this problem in the FullPageOS 0.13.0 RC1 release