### PR TITLE
feat: detect os version and upgrade userconf-pi first (#163)

### DIFF
--- a/src/modules/base/start_chroot_script
+++ b/src/modules/base/start_chroot_script
@@ -36,6 +36,12 @@ if [ "${BASE_DISTRO}" == "ubuntu" ]; then
   
 fi
 
+#Helper Function for create_userconf
+function get_os_version {
+  local os_version
+  grep -c "buster" /etc/os-release
+}
+
 if [ "${BASE_ADD_USER}" == "yes" ]; then
     if [ "${BASE_DISTRO}" == "raspbian" ]; then
         # Setup first user, reference:
@@ -59,7 +65,12 @@ if [ "${BASE_ADD_USER}" == "yes" ]; then
                 exit 1
             fi
         }
-        create_userconf
+        # Do not patch if raspian="buster"
+        if [ "$(get_os_version)" == "0" ]; then
+          create_userconf
+        else
+          echo "Base Image use Version 'buster' no patching of userconf-pi needed"
+        fi
     else
         if id -u "${BASE_USER}" >/dev/null 2>&1; then
             echo "Base user exists, not adding"

--- a/src/modules/base/start_chroot_script
+++ b/src/modules/base/start_chroot_script
@@ -52,7 +52,10 @@ if [ "${BASE_ADD_USER}" == "yes" ]; then
             if [ -n "${BASE_USER}" ] || [ -n "${BASE_USER_PASSWORD}" ]; then
                 pw_encrypt="$(echo "${BASE_USER_PASSWORD}" | openssl passwd -6 -stdin)"
                 echo "${BASE_USER}:${pw_encrypt}" > /boot/userconf.txt
-                
+
+                # Upgrade pkg first, make sure latest version will be patched
+                apt install --yes --only-upgrade userconf-pi
+
                 # Patch cancel-rename due to https://github.com/RPi-Distro/userconf-pi/issues/2
                 # And https://github.com/guysoft/CustomPiOS/issues/163
                 unpack /filesystem/patches /patches root


### PR DESCRIPTION
This should improve behavior of func create_userconf.

As discussed in #163 , this prevents build fails if using 'buster' images
Also, this upgrades 'userconf-pi' package before applying the patch.
This should prevent be overwritten by 'pkgupgrade' module.

Signed-off-by: Stephan Wendel <me@stephanwe.de>