### PR TITLE
feat: add pwrsave script to network module

### DIFF
--- a/src/modules/network/config
+++ b/src/modules/network/config
@@ -1,10 +1,13 @@
 # Network module setup
+# shellcheck=disable
 
 # Use disable power save for wifi module 
 [ -n "$BASE_NETWORK_DISABLE_PWRSAVE" ] || BASE_NETWORK_DISABLE_PWRSAVE=yes
 
-# Type of power save rclocal/service
-# If you use service you will add an systemd.service to enable or disable behavior
+# Type of power save rclocal/service/udev
+# rclocal - backwards compatibility, runs via rc.local
+# service - will add an systemd.service to enable or disable behavior
 # on reboots
+# udev - creates a udev rules that should affect all wifi devices.
 
-[ -n "$BASE_NETWORK_PWRSAVE_TYPE" ] || BASE_NETWORK_PWRSAVE_TYPE=rclocal
+[ -n "$BASE_NETWORK_PWRSAVE_TYPE" ] || BASE_NETWORK_PWRSAVE_TYPE=udev

--- a/src/modules/network/config
+++ b/src/modules/network/config
@@ -1,1 +1,10 @@
-# intentionally left blank
+# Network module setup
+
+# Use disable power save for wifi module 
+[ -n "$BASE_NETWORK_DISABLE_PWRSAVE" ] || BASE_NETWORK_DISABLE_PWRSAVE=yes
+
+# Type of power save rclocal/service
+# If you use service you will add an systemd.service to enable or disable behavior
+# on reboots
+
+[ -n "$BASE_NETWORK_PWRSAVE_TYPE" ] || BASE_NETWORK_PWRSAVE_TYPE=rclocal

--- a/src/modules/network/filesystem/etc/systemd/system/disable-wifi-pwr-mgmt.service
+++ b/src/modules/network/filesystem/etc/systemd/system/disable-wifi-pwr-mgmt.service
@@ -1,0 +1,22 @@
+#### Disable wifi power_save
+####
+#### Written by Stephan Wendel aka KwadFan <me@stephanwe.de>
+#### Copyright 2022
+#### https://github.com/mainsail-crew/MainsailOS
+####
+#### This File is distributed under GPLv3
+####
+#### Note: This is based on:
+#### https://www.intel.com/content/www/us/en/support/articles/000006168/boards-and-kits.html
+
+[Unit]
+Description=Disable power management for wlan0
+After=network.target
+
+[Service]
+Type=oneshot
+StandardOutput=tty
+ExecStart=/usr/local/bin/pwrsave off
+
+[Install]
+WantedBy=multi-user.target

--- a/src/modules/network/filesystem/etc/udev/rules.d/070-wifi-powersave.rules
+++ b/src/modules/network/filesystem/etc/udev/rules.d/070-wifi-powersave.rules
@@ -1,0 +1,4 @@
+ACTION=="add", \
+SUBSYSTEM=="net", \
+KERNEL=="wlan*" \
+RUN+="/usr/sbin/iw %k set power_save off"

--- a/src/modules/network/filesystem/usr/local/bin/pwrsave
+++ b/src/modules/network/filesystem/usr/local/bin/pwrsave
@@ -1,0 +1,90 @@
+#!/bin/bash
+#### Disable wifi power_save
+####
+#### Written by Stephan Wendel aka KwadFan <me@stephanwe.de>
+#### Copyright 2022
+#### https://github.com/mainsail-crew/MainsailOS
+####
+#### This File is distributed under GPLv3
+####
+#### Note: This is based on:
+#### https://www.intel.com/content/www/us/en/support/articles/000006168/boards-and-kits.html
+
+
+## Error handling
+set -eou pipefail
+
+## Debug Mode
+#set -x
+
+### Message func
+function help_msg {
+    echo -e "Usage:\n"
+    echo -e "\tpwrsave [ on | off ]"
+    echo -e "\t\ton\tEnables Power Management of 'wlan0'"
+    echo -e "\t\toff\tDisables Power Management of 'wlan0'\n"
+    exit 1
+}
+
+function has_wifi {
+    LC_ALL=C iwconfig wlan0 &> /dev/null && echo "0" || echo "1"
+}
+
+function check_wifi_present {
+    # make sure to exit if command missing
+    if [ -z "$(command -v iwconfig)" ]; then
+        echo -e "Command 'iwconfig' not found ... [EXITING]"
+        exit 1
+    fi
+    if [ "$(has_wifi)" != "0" ]; then
+        echo -e "[ \e[33mWARN\e[0m ] No WiFi hardware present ... [SKIPPED]"
+        exit 0
+    fi
+}
+
+function disable_pwr_save {
+    iwconfig wlan0 power off
+    echo -e "[  \e[32mOK\e[0m  ] Disabled Power Management for wlan0"
+}
+
+
+function enable_pwr_save {
+    iwconfig wlan0 power on
+    echo -e "[  \e[32mOK\e[0m  ] Enabled Power Management for wlan0"
+}
+
+
+### MAIN
+function main {
+    local arg
+    if [ "$(id -u)" != "0" ]; then
+        echo -e "\n$(basename "${0}"): This script needs root priviledges!\n"
+        exit 1
+    fi
+    if [ "${#}" == "0" ]; then
+        echo -e "$(basename "${0}"): No argument set!"
+        help_msg
+    fi
+    if [ "${#}" -gt 1 ]; then
+        echo -e "$(basename "${0}"): Too many arguments set!"
+        help_msg
+    fi
+    arg="${1}"
+    case "${arg}" in
+        "on")
+            check_wifi_present
+            enable_pwr_save
+        ;;
+        "off")
+            check_wifi_present
+            disable_pwr_save
+        ;;
+        ?|*)
+            echo -e "$(basename "${0}"): Unknown argument '${arg}' !"
+            help_msg
+        ;;
+    esac
+}
+
+main "${@}"
+exit 0

--- a/src/modules/network/filesystem/usr/local/bin/pwrsave-udev
+++ b/src/modules/network/filesystem/usr/local/bin/pwrsave-udev
@@ -1,0 +1,105 @@
+#!/bin/bash
+#### Disable wifi power_save
+####
+#### Written by Stephan Wendel aka KwadFan <me@stephanwe.de>
+#### Copyright 2022
+#### https://github.com/mainsail-crew/MainsailOS
+####
+#### This File is distributed under GPLv3
+####
+#### Note: This is based on:
+#### https://www.intel.com/content/www/us/en/support/articles/000006168/boards-and-kits.html
+
+
+## Error handling
+set -eou pipefail
+
+## Debug Mode
+#set -x
+
+### Message func
+function help_msg {
+    echo -e "Usage:\n"
+    echo -e "\tpwrsave-udev [ on | off | create ]"
+    echo -e "\t\ton\tEnables Power Management via udev rule"
+    echo -e "\t\toff\tDisables Power Management via udev rule"
+    echo -e "\t\tcreate\tCreate Power Management udev rule\n"
+    exit 1
+}
+
+
+### Check rule exist
+function check_rule {
+    if [ ! -f /etc/udev/rules.d/070-wifi-powersave.rules ]; then
+        echo -e "[  \e[31mERROR\e[0m  ] Udev Rule for WiFi Powermanagement not found!"
+        help_msg
+        exit 1
+    fi
+}
+
+function disable_pwr_save {
+    sed -i 's/on/off/' /etc/udev/rules.d/070-wifi-powersave.rules
+    echo -e "[  \e[32mOK\e[0m  ] Disabled Power Management"
+}
+
+
+function enable_pwr_save {
+    sed -i 's/off/on/' /etc/udev/rules.d/070-wifi-powersave.rules
+    echo -e "[  \e[32mOK\e[0m  ] Enabled Power Management"
+}
+
+function create_rule {
+if [ -f /etc/udev/rules.d/070-wifi-powersave.rules ]; then
+    echo -e "[  \e[33mSKIPPED\e[0m  ] Udev rule already exists!"
+    exit 0
+fi
+
+cat << EOF > /etc/udev/rules.d/070-wifi-powersave.rules
+ACTION=="add", \
+SUBSYSTEM=="net", \
+KERNEL=="wlan*" \
+RUN+="/usr/sbin/iw %k set power_save off"
+EOF
+echo -e "[  \e[32mOK\e[0m  ] Created Udev rule ... \n"
+echo -e "Please 'reboot' to take changes effect.\n"
+}
+
+
+
+### MAIN
+function main {
+    local arg
+    if [ "$(id -u)" != "0" ]; then
+        echo -e "\n$(basename "${0}"): This script needs root priviledges!\n"
+        exit 1
+    fi
+    if [ "${#}" == "0" ]; then
+        echo -e "$(basename "${0}"): No argument set!"
+        help_msg
+    fi
+    if [ "${#}" -gt 1 ]; then
+        echo -e "$(basename "${0}"): Too many arguments set!"
+        help_msg
+    fi
+    arg="${1}"
+    if [ "${arg}" == "create" ]; then
+        create_rule
+        exit 0
+    fi
+    check_rule
+    case "${arg}" in
+        "on")
+            enable_pwr_save
+        ;;
+        "off")
+            disable_pwr_save
+        ;;
+        ?|*)
+            echo -e "$(basename "${0}"): Unknown argument '${arg}' !"
+            help_msg
+        ;;
+    esac
+}
+
+main "${@}"
+exit 0

--- a/src/modules/network/start_chroot_script
+++ b/src/modules/network/start_chroot_script
@@ -50,11 +50,24 @@ sed -i 's@exit 0@@' /etc/rc.local
 echo '/sbin/iptables -t mangle -I POSTROUTING 1 -o wlan0 -p udp --dport 123 -j TOS --set-tos 0x00' >> /etc/rc.local
 echo 'exit 0' >> /etc/rc.local
 
-# Turn off wlan power management
-sed -i 's@exit 0@@' /etc/rc.local
-cat <<'EOT' >> /etc/rc.local
-echo "Disabling power management for wlan0" 
-iw dev wlan0 set power_save off
-EOT
+# Install powersave option
+if [ "$BASE_NETWORK_DISABLE_PWRSAVE" == "yes" ]; then
 
+  # Copy pwrsave script
+  unpack filesystem/usr/local/bin /usr/local/bin root
 
+  # Use rc.local
+  if [ "$BASE_NETWORK_PWRSAVE_TYPE" == "rclocal" ]; then
+    echo_green "Modifying /etc/rc.local ..."
+    sed -i 's@exit 0@@' /etc/rc.local
+    (echo "# Disable WiFi Power Management"; \
+    echo 'echo "Disabling power management for wlan0 ..."' ; \
+    echo "/usr/local/bin/pwrsave off"; echo "exit 0") >> /etc/rc.local
+  fi
+  # Use service
+  if [ "$BASE_NETWORK_PWRSAVE_TYPE" == "service" ]; then
+    echo_green "Installing disable-wifi-pwr-mgmt service ..."
+    unpack filesystem/etc/systemd/system /etc/systemd/system root
+    systemctl_if_exists enable disable-wifi-pwr-mgmt.service
+  fi
+fi

--- a/src/modules/network/start_chroot_script
+++ b/src/modules/network/start_chroot_script
@@ -70,4 +70,15 @@ if [ "$BASE_NETWORK_DISABLE_PWRSAVE" == "yes" ]; then
     unpack filesystem/etc/systemd/system /etc/systemd/system root
     systemctl_if_exists enable disable-wifi-pwr-mgmt.service
   fi
+  # Use udev rule
+  if [ "$BASE_NETWORK_PWRSAVE_TYPE" == "udev" ]; then
+    echo_green "Installing WiFi Power Management udev rule ..."
+    unpack filesystem/etc/udev/rules.d /etc/udev/rules.d root
+  fi
+  # strip out unneeded script, depending on choose
+  if [ "$BASE_NETWORK_PWRSAVE_TYPE" != "udev" ]; then
+    rm -f /usr/local/bin/pwrsave-udev
+  else
+    rm -f /usr/local/bin/pwrsave
+  fi
 fi


### PR DESCRIPTION
This changes allow to customize behavior of network modules power save
for wifi.

The used method spits out an error if the device has no wifi built in,
which confuses the user.

To prevent that I implemented a simple solution that the user only get a
warning if no wifi device present.

Also added functionality to disable the whole mechanism.
You can choose a standard rc.local entry or
a systemd service to manipulate behavior on reboots
(Enable/Disable the service)

Signed-off-by: Stephan Wendel <me@stephanwe.de>