### PR TITLE
fix: fixes error not parsed variables #168

### DIFF
--- a/src/modules/network/config
+++ b/src/modules/network/config
@@ -2,7 +2,7 @@
 # shellcheck=disable
 
 # Use disable power save for wifi module 
-[ -n "$BASE_NETWORK_DISABLE_PWRSAVE" ] || BASE_NETWORK_DISABLE_PWRSAVE=yes
+[ -n "$NETWORK_DISABLE_PWRSAVE" ] || NETWORK_DISABLE_PWRSAVE=yes
 
 # Type of power save rclocal/service/udev
 # rclocal - backwards compatibility, runs via rc.local
@@ -10,4 +10,4 @@
 # on reboots
 # udev - creates a udev rules that should affect all wifi devices.
 
-[ -n "$BASE_NETWORK_PWRSAVE_TYPE" ] || BASE_NETWORK_PWRSAVE_TYPE=udev
+[ -n "$NETWORK_PWRSAVE_TYPE" ] || NETWORK_PWRSAVE_TYPE=udev

--- a/src/modules/network/start_chroot_script
+++ b/src/modules/network/start_chroot_script
@@ -51,13 +51,13 @@ echo '/sbin/iptables -t mangle -I POSTROUTING 1 -o wlan0 -p udp --dport 123 -j T
 echo 'exit 0' >> /etc/rc.local
 
 # Install powersave option
-if [ "$BASE_NETWORK_DISABLE_PWRSAVE" == "yes" ]; then
+if [ "$NETWORK_DISABLE_PWRSAVE" == "yes" ]; then
 
   # Copy pwrsave script
   unpack filesystem/usr/local/bin /usr/local/bin root
 
   # Use rc.local
-  if [ "$BASE_NETWORK_PWRSAVE_TYPE" == "rclocal" ]; then
+  if [ "$NETWORK_PWRSAVE_TYPE" == "rclocal" ]; then
     echo_green "Modifying /etc/rc.local ..."
     sed -i 's@exit 0@@' /etc/rc.local
     (echo "# Disable WiFi Power Management"; \
@@ -65,18 +65,18 @@ if [ "$BASE_NETWORK_DISABLE_PWRSAVE" == "yes" ]; then
     echo "/usr/local/bin/pwrsave off"; echo "exit 0") >> /etc/rc.local
   fi
   # Use service
-  if [ "$BASE_NETWORK_PWRSAVE_TYPE" == "service" ]; then
+  if [ "$NETWORK_PWRSAVE_TYPE" == "service" ]; then
     echo_green "Installing disable-wifi-pwr-mgmt service ..."
     unpack filesystem/etc/systemd/system /etc/systemd/system root
     systemctl_if_exists enable disable-wifi-pwr-mgmt.service
   fi
   # Use udev rule
-  if [ "$BASE_NETWORK_PWRSAVE_TYPE" == "udev" ]; then
+  if [ "$NETWORK_PWRSAVE_TYPE" == "udev" ]; then
     echo_green "Installing WiFi Power Management udev rule ..."
     unpack filesystem/etc/udev/rules.d /etc/udev/rules.d root
   fi
   # strip out unneeded script, depending on choose
-  if [ "$BASE_NETWORK_PWRSAVE_TYPE" != "udev" ]; then
+  if [ "$NETWORK_PWRSAVE_TYPE" != "udev" ]; then
     rm -f /usr/local/bin/pwrsave-udev
   else
     rm -f /usr/local/bin/pwrsave


### PR DESCRIPTION
As mentioned in #169
I killed the whole functionality of that module.

Because Variables are declared as BASE_NETWORK,
the module will not be configured at all.

Variables has to start with module name in capital letters to be parsed
by CustomPIOS

Signed-off-by: Stephan Wendel <me@stephanwe.de>