### PR TITLE
Allow change from, e.g., stable to oldstable

### DIFF
--- a/src/modules/admin-toolkit/start_chroot_script
+++ b/src/modules/admin-toolkit/start_chroot_script
@@ -95,7 +95,7 @@ fi
 # Begin general section
 if [ "$ADMIN_TOOLKIT_UPDATE_PACKAGES" == "yes" ]
 then
-    apt-get update && apt-get upgrade -y
+    apt-get update --allow-relreaseinfo-change && apt-get upgrade -y
 fi
 
 # Install packages if listed

--- a/src/modules/auto-hotspot/start_chroot_script
+++ b/src/modules/auto-hotspot/start_chroot_script
@@ -10,7 +10,7 @@ set -e
 
 source /common.sh
 
-apt-get update
+apt-get update --allow-relreaseinfo-change
 apt-get -y purge dns-root-data
 apt-get -y install iw
 

--- a/src/modules/auto-mount-removable/start_chroot_script
+++ b/src/modules/auto-mount-removable/start_chroot_script
@@ -9,7 +9,7 @@ set -e
 
 source /common.sh
 
-apt-get update
+apt-get update --allow-relreaseinfo-change
 apt-get install -y usbmount
 
 unpack /filesystem/root /

--- a/src/modules/base/start_chroot_script
+++ b/src/modules/base/start_chroot_script
@@ -20,7 +20,7 @@ if [ "${BASE_DISTRO}" == "ubuntu" ]; then
   echo "nameserver 8.8.4.4" >> /etc/resolv.conf
   echo "nameserver 1.1.1.1" >> /etc/resolv.conf
   
-  apt-get update
+  apt-get update --allow-relreaseinfo-change
   apt-get install -y net-tools wireless-tools dhcpcd5
   if [ $( is_in_apt policykit-1 ) -eq 1 ]; then
     apt-get -y install policykit-1

--- a/src/modules/disable-services/start_chroot_script
+++ b/src/modules/disable-services/start_chroot_script
@@ -9,7 +9,7 @@ set -ex
 source /common.sh
 install_cleanup_trap
 
-apt-get update --allow-releaseinfo-change
+apt-get update --allow-relreaseinfo-change --allow-releaseinfo-change
 if [ $( is_in_apt policykit-1 ) -eq 1 ]; then
   sudo apt-get -y install policykit-1
 fi

--- a/src/modules/docker/start_chroot_script
+++ b/src/modules/docker/start_chroot_script
@@ -19,7 +19,7 @@ elif [ "${BASE_DISTRO}" == "ubuntu" ]; then
         echo "Error, not implemented Ubuntu 32bit"
 	exit 1
     fi
-    apt-get update
+    apt-get update --allow-relreaseinfo-change
     apt-get install -y docker-ce
 fi
 

--- a/src/modules/ffmpeg/start_chroot_script
+++ b/src/modules/ffmpeg/start_chroot_script
@@ -9,7 +9,7 @@ set -ex
 source /common.sh
 install_cleanup_trap
 
-apt-get update
+apt-get update --allow-relreaseinfo-change
 apt-get install -y checkinstall git
 
 pushd /usr/src

--- a/src/modules/gui/start_chroot_script
+++ b/src/modules/gui/start_chroot_script
@@ -14,11 +14,11 @@ unpack /filesystem/root_init /
 echo exit 101 > /usr/sbin/policy-rc.d
 chmod +x /usr/sbin/policy-rc.d
 
-apt-get update
+apt-get update --allow-relreaseinfo-change
 apt-get install -y --force-yes matchbox-window-manager xorg lightdm
 if [ "$GUI_INCLUDE_ACCELERATION" == "yes" ]
     then
-        apt-get update
+        apt-get update --allow-relreaseinfo-change
         apt-get -y --force-yes install xcompmgr libgl1-mesa-dri mesa-utils compton libconfig9
         
         # Hack to pass non-interactive install

--- a/src/modules/install-linux-modules-extra/start_chroot_script
+++ b/src/modules/install-linux-modules-extra/start_chroot_script
@@ -15,7 +15,7 @@ install_cleanup_trap
 
 # unpack /filesystem/root /
 
-apt-get update
+apt-get update --allow-relreaseinfo-change
 # workwround to intall linux-modules-extra-raspi
 sudo umount /boot
 

--- a/src/modules/kernel/start_chroot_script
+++ b/src/modules/kernel/start_chroot_script
@@ -14,7 +14,7 @@ install_cleanup_trap
 
 
 pushd /home/pi
-    sudo apt-get update
+    sudo apt-get update --allow-relreaseinfo-change
     sudo apt-get -y install make gcc git bc p7zip-full bison flex libssl-dev
     
     # git clone --depth=1 https://github.com/raspberrypi/linux

--- a/src/modules/mysql/start_chroot_script
+++ b/src/modules/mysql/start_chroot_script
@@ -10,7 +10,7 @@ set -e
 source /common.sh
 install_cleanup_trap
 
-apt-get update
+apt-get update --allow-relreaseinfo-change
 apt-get install -y mariadb-server expect
 
 mysqld_safe &

--- a/src/modules/network/start_chroot_script
+++ b/src/modules/network/start_chroot_script
@@ -44,7 +44,7 @@ if [ ! -f "/etc/rc.local" ];then
 fi
 
 # prevent ntp updates from failing due to some Rpi3 weirdness, see also "Fix SSH" further below
-apt-get update
+apt-get update --allow-relreaseinfo-change
 apt-get install -y iptables
 sed -i 's@exit 0@@' /etc/rc.local
 echo '/sbin/iptables -t mangle -I POSTROUTING 1 -o wlan0 -p udp --dport 123 -j TOS --set-tos 0x00' >> /etc/rc.local

--- a/src/modules/usage-statistics/start_chroot_script
+++ b/src/modules/usage-statistics/start_chroot_script
@@ -9,7 +9,7 @@ set -e
 
 source /common.sh
 
-apt-get update
+apt-get update --allow-relreaseinfo-change
 apt-get -y install curl
 
 unpack /filesystem/root /

--- a/src/variants/armbian/pre_chroot_script
+++ b/src/variants/armbian/pre_chroot_script
@@ -52,7 +52,7 @@ if [ -n "$BASE_APT_CACHE" ] && [ "$BASE_APT_CACHE" != "no" ]; then
 else
   apt-get clean
 fi
-apt-get update || true
+apt-get update --allow-relreaseinfo-change || true
 apt-get -y --force-yes install avahi-daemon || true
 apt-get -y --force-yes install iptables
 


### PR DESCRIPTION
When building buster images, the change from stable to oldstable breaks some automation (including the ZynthianOS build) with a non-zero exit status and a message to the following effect:

`N: Repository 'http://raspbian.raspberrypi.org/raspbian buster InRelease' changed its 'Suite' value from 'stable' to 'oldstable'`

This change allows the change in Suite value without complaint or ill effect.