### PR TITLE
Change none-compatible to incompatible

### DIFF
--- a/src/modules/network/filesystem/boot/custompios-wpa-supplicant.txt
+++ b/src/modules/network/filesystem/boot/custompios-wpa-supplicant.txt
@@ -20,7 +20,7 @@
 #
 # If you use Textedit to edit this file make sure to use "plain text format"
 # and "disable smart quotes" in "Textedit > Preferences", otherwise Textedit
-# will use none-compatible characters and your network configuration won't
+# will use non-compatible characters and your network configuration won't
 # work!
 
 ## WPA/WPA2 secured

--- a/src/modules/network/filesystem/boot/custompios-wpa-supplicant.txt
+++ b/src/modules/network/filesystem/boot/custompios-wpa-supplicant.txt
@@ -20,7 +20,7 @@
 #
 # If you use Textedit to edit this file make sure to use "plain text format"
 # and "disable smart quotes" in "Textedit > Preferences", otherwise Textedit
-# will use non-compatible characters and your network configuration won't
+# will use incompatible characters and your network configuration won't
 # work!
 
 ## WPA/WPA2 secured


### PR DESCRIPTION
Correct typo, from `none-compatible` to `incompatible`. According to https://english.stackexchange.com/questions/55596/is-noncompatible-a-legitimate-synonym-of-incompatible, `noncompatible` isn't standard, and it doesn't include the hyphen.