### PR TITLE
fix: docker now works for raspios64

### DIFF
--- a/src/modules/docker/start_chroot_script
+++ b/src/modules/docker/start_chroot_script
@@ -9,7 +9,7 @@ set -ex
 source /common.sh
 install_cleanup_trap
 
-if [ "${BASE_DISTRO}" == "raspbian" ]; then
+if [ "${BASE_DISTRO}" == "raspbian" ] || [ "${BASE_DISTRO}" == "raspios64" ]; then
         curl -sSL get.docker.com | sh
 elif [ "${BASE_DISTRO}" == "ubuntu" ]; then
     apt-get update


### PR DESCRIPTION
The docker module did not work when selecting raspios64 as BASE_DISTRO. This tiny commit changes that (I have confirmed that it also works with raspios64 as expected)