### PR TITLE
replace arch with uname -m

### DIFF
--- a/src/custompios
+++ b/src/custompios
@@ -12,7 +12,7 @@ source ${CUSTOM_PI_OS_PATH}/common.sh
 function execute_chroot_script() {
 
   # In docker, these extra commands are required to enable this black-magic
-  if [ -f /.dockerenv ] && [ "$(arch)" != "armv7l" ] && [ "$(arch)" != "aarch64" ] ; then
+  if [ -f /.dockerenv ] && [ "$(uname -m)" != "armv7l" ] && [ "$(uname -m)" != "aarch64" ] ; then
     if [ "$BASE_ARCH" == "armv7l" ]; then
       update-binfmts --enable qemu-arm
     elif [ "$BASE_ARCH" == "aarch64" ] || [ "$BASE_ARCH" == "arm64" ]; then
@@ -27,7 +27,7 @@ function execute_chroot_script() {
 
   #black magic of qemu-arm-static
   # cp `which qemu-arm-static` usr/bin
-  if [ "$(arch)" != "armv7l" ] && [ "$(arch)" != "aarch64" ] ; then
+  if [ "$(uname -m)" != "armv7l" ] && [ "$(uname -m)" != "aarch64" ] ; then
     if [ "$BASE_ARCH" == "armv7l" ]; then
       cp `which qemu-arm-static` usr/bin/qemu-arm-static
     elif [ "$BASE_ARCH" == "aarch64" ] || [ "$BASE_ARCH" == "arm64" ]; then
@@ -40,7 +40,7 @@ function execute_chroot_script() {
   cp "${CUSTOM_PI_OS_PATH}"/common.sh common.sh
   chmod 755 common.sh
   
-  if [ "$(arch)" != "armv7l" ] && [ "$(arch)" != "aarch64" ] && [ "$(arch)" != "arm64" ] ; then
+  if [ "$(uname -m)" != "armv7l" ] && [ "$(uname -m)" != "aarch64" ] && [ "$(uname -m)" != "arm64" ] ; then
     if [ "$BASE_ARCH" == "armv7l" ]; then
       echo "Building on non-ARM device a armv7l system, using qemu-arm-static"
       chroot . usr/bin/qemu-arm-static /bin/bash /chroot_script


### PR DESCRIPTION
The `arch` command isn't particularly well standardized compared to `uname -m`. For example, coreutils on Archlinux doesn't provide it, and it's generally not recommended to rely on it.

See e.g. https://www.gnu.org/software/coreutils/manual/html_node/arch-invocation.html:

> arch is not installed by default, so portable scripts should not rely on its existence. 