### PR TITLE
armbian: automatically bring up eth0

### DIFF
--- a/src/variants/armbian/filesystem/root/etc/network/interfaces
+++ b/src/variants/armbian/filesystem/root/etc/network/interfaces
@@ -9,6 +9,7 @@ source-directory /etc/network/interfaces.d
 auto lo
 iface lo inet loopback
 
+auto eth0
 iface eth0 inet dhcp
 
 allow-hotplug wlan0


### PR DESCRIPTION
Without `auto eth0`, the eth0 interface stays down.