### PR TITLE
src/custompios: add gentoo linux build support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Developing
 Requirements
 ~~~~~~~~~~~~
 
-#. `qemu-arm-static <http://packages.debian.org/sid/qemu-user-static>`_
+#. `qemu-arm-static <http://packages.debian.org/sid/qemu-user-static>`_ or gentoo qemu with static USE
 #. Downloaded `Raspbian <http://www.raspbian.org/>`_ image.
 #. root privileges for chroot
 #. Bash
@@ -63,7 +63,7 @@ Requirements
 Known to work building configurations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1. Using the `CustomPiOS docker image <https://hub.docker.com/r/guysoft/custompios>`_
-2. Linux (Ubuntu / Debian etc)
+2. Linux (Ubuntu / Debian / Gentoo etc)
 3. OS X -  `See this thread for information <https://github.com/guysoft/OctoPi/issues/388#issuecomment-316327106>`_
 
 

--- a/src/custompios
+++ b/src/custompios
@@ -29,9 +29,17 @@ function execute_chroot_script() {
   # cp `which qemu-arm-static` usr/bin
   if [ "$(arch)" != "armv7l" ] && [ "$(arch)" != "aarch64" ] ; then
     if [ "$BASE_ARCH" == "armv7l" ]; then
-      cp `which qemu-arm-static` usr/bin/qemu-arm-static
+      if (grep -q gentoo /etc/os-release);then
+        ROOT="`realpath .`" emerge --usepkgonly --oneshot --nodeps qemu
+      else
+        cp `which qemu-arm-static` usr/bin/qemu-arm-static
+      fi
     elif [ "$BASE_ARCH" == "aarch64" ] || [ "$BASE_ARCH" == "arm64" ]; then
-      cp `which qemu-aarch64-static` usr/bin/qemu-aarch64-static
+      if (grep -q gentoo /etc/os-release);then
+        ROOT="`realpath .`" emerge --usepkgonly --oneshot --nodeps qemu
+      else
+        cp `which qemu-aarch64-static` usr/bin/qemu-aarch64-static
+      fi
     fi
   fi
   
@@ -43,10 +51,18 @@ function execute_chroot_script() {
   if [ "$(arch)" != "armv7l" ] && [ "$(arch)" != "aarch64" ] && [ "$(arch)" != "arm64" ] ; then
     if [ "$BASE_ARCH" == "armv7l" ]; then
       echo "Building on non-ARM device a armv7l system, using qemu-arm-static"
-      chroot . usr/bin/qemu-arm-static /bin/bash /chroot_script
+      if (grep -q gentoo /etc/os-release);then
+        chroot . usr/bin/qemu-arm /bin/bash /chroot_script
+      else
+        chroot . usr/bin/qemu-arm-static /bin/bash /chroot_script
+      fi
     elif [ "$BASE_ARCH" == "aarch64" ] || [ "$BASE_ARCH" == "arm64" ]; then
       echo "Building on non-ARM device a aarch64/arm64 system, using qemu-aarch64-static"
-      chroot . usr/bin/qemu-aarch64-static /bin/bash /chroot_script
+      if (grep -q gentoo /etc/os-release);then
+        chroot . usr/bin/qemu-aarch64 /bin/bash /chroot_script
+      else
+        chroot . usr/bin/qemu-aarch64-static /bin/bash /chroot_script
+      fi
     fi
   else
     echo "Building on ARM device a armv7l/aarch64/arm64 system, not using qemu"


### PR DESCRIPTION
case gentoo's qemu binary name is not same as debian and other distros, build with docker and systemd-nspawn qemu is broken, need to spec binary name to use