### PR TITLE
allow setting boot partition

### DIFF
--- a/src/common.sh
+++ b/src/common.sh
@@ -171,15 +171,22 @@ function mount_image() {
   mount_path=$3
   
   boot_mount_path=boot
+
   if [ "$#" -gt 3 ]
   then
     boot_mount_path=$4
+  fi
+
+  if [ "$#" -gt 4 ]
+  then
+    boot_partition=$5
+  else
+    boot_partition=1
   fi
   
   echo $2
 
   # dump the partition table, locate boot partition and root partition
-  boot_partition=1
   fdisk_output=$(sfdisk -d $image_path)
   boot_offset=$(($(echo "$fdisk_output" | grep "$image_path$boot_partition" | awk '{print $4-0}') * 512))
   root_offset=$(($(echo "$fdisk_output" | grep "$image_path$root_partition" | awk '{print $4-0}') * 512))

--- a/src/custompios
+++ b/src/custompios
@@ -113,7 +113,7 @@ pushd $BASE_WORKSPACE
   fi
 
   # mount root and boot partition
-  mount_image "${BASE_IMG_PATH}" "${BASE_ROOT_PARTITION}" "${BASE_MOUNT_PATH}" "${BASE_BOOT_MOUNT_PATH}"
+  mount_image "${BASE_IMG_PATH}" "${BASE_ROOT_PARTITION}" "${BASE_MOUNT_PATH}" "${BASE_BOOT_MOUNT_PATH}" "${BASE_BOOT_PARTITION}"
   if [ -n "$BASE_APT_CACHE" ] && [ "$BASE_APT_CACHE" != "no" ]
   then
     mkdir -p "$BASE_APT_CACHE"

--- a/src/qemu_boot.sh
+++ b/src/qemu_boot.sh
@@ -25,7 +25,7 @@ if [ ! -f "${BASE_IMG_PATH}" ]; then
     BASE_MOUNT_PATH=${DEST}/mount
     mkdir -p "${BASE_MOUNT_PATH}"
     
-    sudo bash -c "$(declare -f mount_image); $(declare -f detach_all_loopback); mount_image $BASE_IMG_PATH $BASE_ROOT_PARTITION $BASE_MOUNT_PATH"
+    sudo bash -c "$(declare -f mount_image); $(declare -f detach_all_loopback); mount_image $BASE_IMG_PATH $BASE_ROOT_PARTITION $BASE_MOUNT_PATH $BASE_BOOT_MOUNT_PATH $BASE_BOOT_PARTITION"
     
     pushd "${BASE_MOUNT_PATH}"
     sudo bash -c "$(declare -f fixLd); fixLd"

--- a/src/qemu_boot64.sh
+++ b/src/qemu_boot64.sh
@@ -25,7 +25,7 @@ if [ ! -f "${BASE_IMG_PATH}" ]; then
     BASE_MOUNT_PATH=${DEST}/mount
     mkdir -p "${BASE_MOUNT_PATH}"
     
-    sudo bash -c "$(declare -f mount_image); $(declare -f detach_all_loopback); mount_image $BASE_IMG_PATH $BASE_ROOT_PARTITION $BASE_MOUNT_PATH"
+    sudo bash -c "$(declare -f mount_image); $(declare -f detach_all_loopback); mount_image $BASE_IMG_PATH $BASE_ROOT_PARTITION $BASE_MOUNT_PATH $BASE_BOOT_MOUNT_PATH $BASE_BOOT_PARTITION"
     
     pushd "${BASE_MOUNT_PATH}"
     sudo bash -c "$(declare -f fixLd); fixLd"


### PR DESCRIPTION
This change allows setting a custom boot partition instead of relying on the current heuristic of either assuming it's the same as the root, or is partition 1. For example, rockpi images come with a GPT partition table where boot is partition 4 and root is 5.

The order of arguments to `mount_image` is a bit weird now, but it keeps maximum backwards compatibility.