### PR TITLE
`make_custom_pi_os` improvements

### DIFF
--- a/src/dist_generators/dist_example_script
+++ b/src/dist_generators/dist_example_script
@@ -1,18 +1,25 @@
 #!/usr/bin/env bash
+set -euo pipefail
 DEST_FOLDER="$1"
 
-DIST_NAME=$(basename $DEST_FOLDER)
+DIST_NAME=$(basename "${DEST_FOLDER}")
 
-pushd "${DEST_FOLDER}" > /dev/null
-    pushd src/modules > /dev/null
-        mv example ${DIST_NAME,,}
-        pushd ${DIST_NAME,,} > /dev/null
-            DIST_NAME_UPPER=$(echo $DIST_NAME | awk '{print toupper($0)}')
-            sed -i "s/EXAMPLE_VAR/${DIST_NAME_UPPER}_VAR/g" config start_chroot_script
-        popd > /dev/null
-    popd > /dev/null
-    pushd src > /dev/null
-        sed -i "s/export DIST_NAME=.*/export DIST_NAME=${DIST_NAME}/g" config
-        sed -i "s/example/${DIST_NAME,,}/g" config
-    popd > /dev/null
-popd > /dev/null
+if which gsed >/dev/null; then # use gnu sed if available (macos)
+    SED="gsed"
+else
+    SED="sed"
+fi
+
+pushd "${DEST_FOLDER}" >/dev/null || exit 1
+    pushd src/modules >/dev/null || exit 1
+        mv example "${DIST_NAME,,}"
+        pushd "${DIST_NAME,,}" >/dev/null || exit 1
+            DIST_NAME_UPPER=$(echo "${DIST_NAME}" | awk '{print toupper($0)}')
+            ${SED} -i "s/EXAMPLE_VAR/${DIST_NAME_UPPER}_VAR/g" config start_chroot_script
+        popd >/dev/null || exit 1
+    popd >/dev/null || exit 1
+    pushd src >/dev/null || exit 1
+        ${SED} -i "s/export DIST_NAME=.*/export DIST_NAME=${DIST_NAME}/g" config
+        ${SED} -i "s/example/${DIST_NAME,,}/g" config
+    popd >/dev/null || exit 1
+popd >/dev/null || exit 1

--- a/src/make_custom_pi_os
+++ b/src/make_custom_pi_os
@@ -8,10 +8,15 @@ argparse "$@" <<EOF || exit 1
 parser.add_argument('dest', help="The destination folder")
 parser.add_argument('-g', '--get_image', action='store_true',
                     help='Pick a number [default %(default)s]')
+parser.add_argument('-v', '--variant', action='store',
+                    choices=['raspios_lite_armhf', 'raspios_lite_arm64'],
+                    default='raspios_lite_armhf',
+                    help='Which variant to use [default: %(default)s]')
 EOF
 
 echo Settings:
-echo making dstro in "$DEST"
+echo "making dstro in ${DEST}"
+echo "variant: ${VARIANT}"
 
 for a in "${MULTIPLE[@]}"; do
     echo "  $a"
@@ -37,17 +42,17 @@ chown -R "${USER}":"$(id -gn "${USER}")" "${DEST}"
 if [ "$GET_IMAGE" ]; then
     echo -n "Downloading latest Raspbian image"
 
-    CURRENT_RASPBIAN=$(curl -s https://downloads.raspberrypi.org/raspios_lite_armhf/images/ | grep raspios | tail -n 1 | awk -F "href=\"" '{print $2}' | awk -F "/" '{print $1}')
+    CURRENT_RASPBIAN=$(curl -s "https://downloads.raspberrypi.org/${VARIANT}/images/" | grep raspios | tail -n 1 | awk -F "href=\"" '{print $2}' | awk -F "/" '{print $1}')
     if [ $? -ne 0 ]; then
         echo -e "\nerror getting date"
         exit 1
     fi
-    CURRENT_RASPBIAN_FILE="$(curl -s "http://downloads.raspberrypi.org/raspios_lite_armhf/images/${CURRENT_RASPBIAN}"/ | grep .xz | head -n 1 | awk -F "href=\"" '{print $2}' | awk -F "\">" '{print $1}')"
+    CURRENT_RASPBIAN_FILE="$(curl -s "http://downloads.raspberrypi.org/${VARIANT}/images/${CURRENT_RASPBIAN}"/ | grep .xz | head -n 1 | awk -F "href=\"" '{print $2}' | awk -F "\">" '{print $1}')"
     if [ $? -ne 0 ]; then
         echo -e "\nerror getting file name"
         exit 1
     fi
-    CURRENT_RASPBIAN_URL="https://downloads.raspberrypi.org/raspios_lite_armhf/images/${CURRENT_RASPBIAN}/${CURRENT_RASPBIAN_FILE}"
+    CURRENT_RASPBIAN_URL="https://downloads.raspberrypi.org/${VARIANT}/images/${CURRENT_RASPBIAN}/${CURRENT_RASPBIAN_FILE}"
     echo " from ${CURRENT_RASPBIAN_URL}"
     curl -L -o "${DEST}/src/image/${CURRENT_RASPBIAN_FILE}" "${CURRENT_RASPBIAN_URL}"
 fi

--- a/src/make_custom_pi_os
+++ b/src/make_custom_pi_os
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 source "$DIR/argparse.bash" || exit 1
 argparse "$@" <<EOF || exit 1
@@ -9,41 +10,44 @@ parser.add_argument('-g', '--get_image', action='store_true',
                     help='Pick a number [default %(default)s]')
 EOF
 
-echo Settings: 
+echo Settings:
 echo making dstro in "$DEST"
-
-DIST_NAME=$(basename "$DEST")
 
 for a in "${MULTIPLE[@]}"; do
     echo "  $a"
 done
 
-if [ -d ${DEST} ]; then
+if [ -d "${DEST}" ]; then
     echo "Error, folder already exists: ${DEST}"
     exit 1
 fi
 
-if [ -f ${DEST} ]; then
+if [ -f "${DEST}" ]; then
     echo "Error, file already exists: ${DEST}"
     exit 1
 fi
 
-cp -a ${DIR}/dist_generators/dist_example "${DEST}"
-chown $USER:$USER -R ${DEST}
+cp -a "${DIR}/dist_generators/dist_example" "${DEST}"
+chown -R "${USER}":"$(id -gn "${USER}")" "${DEST}"
 
-${DIR}/dist_generators/dist_example_script "${DEST}"
+"${DIR}/dist_generators/dist_example_script" "${DEST}"
 
 "$DIR/update-custompios-paths" "${DEST}/src"
 
-if [ $GET_IMAGE ]; then
-    echo "Downloading latest Raspbian image"
-    
-    CURRENT_RASPBIAN=$(curl https://downloads.raspberrypi.org/raspios_lite_armhf/images/ | grep raspios | tail -n 1 | awk -F "href=\"" '{print $2}' | awk -F "/" '{print $1}')
+if [ "$GET_IMAGE" ]; then
+    echo -n "Downloading latest Raspbian image"
+
+    CURRENT_RASPBIAN=$(curl -s https://downloads.raspberrypi.org/raspios_lite_armhf/images/ | grep raspios | tail -n 1 | awk -F "href=\"" '{print $2}' | awk -F "/" '{print $1}')
     if [ $? -ne 0 ]; then
-        echo "error getting date"
+        echo -e "\nerror getting date"
         exit 1
     fi
-    CURRENT_RASPBIAN_FILE=$(curl http://downloads.raspberrypi.org/raspios_lite_armhf/images/${CURRENT_RASPBIAN}/ | grep .xz | head -n 1 | awk -F "href=\"" '{print $2}' | awk -F "\">" '{print $1}')
-    curl -L -o "${DEST}/src/image/${CURRENT_RASPBIAN_FILE}" https://downloads.raspberrypi.org/raspios_lite_armhf/images/${CURRENT_RASPBIAN}/${CURRENT_RASPBIAN_FILE}
+    CURRENT_RASPBIAN_FILE="$(curl -s "http://downloads.raspberrypi.org/raspios_lite_armhf/images/${CURRENT_RASPBIAN}"/ | grep .xz | head -n 1 | awk -F "href=\"" '{print $2}' | awk -F "\">" '{print $1}')"
+    if [ $? -ne 0 ]; then
+        echo -e "\nerror getting file name"
+        exit 1
+    fi
+    CURRENT_RASPBIAN_URL="https://downloads.raspberrypi.org/raspios_lite_armhf/images/${CURRENT_RASPBIAN}/${CURRENT_RASPBIAN_FILE}"
+    echo " from ${CURRENT_RASPBIAN_URL}"
+    curl -L -o "${DEST}/src/image/${CURRENT_RASPBIAN_FILE}" "${CURRENT_RASPBIAN_URL}"
 fi
-

--- a/src/make_custom_pi_os
+++ b/src/make_custom_pi_os
@@ -14,6 +14,19 @@ parser.add_argument('-v', '--variant', action='store',
                     help='Which variant to use [default: %(default)s]')
 EOF
 
+case $DEST in
+    *"-"*)
+        echo "Error, destination folder cannot contain a dash"
+        exit 1
+        ;;
+    *" "*)
+        echo "Error, destination folder cannot contain a space"
+        exit 1
+        ;;
+    *)
+        ;;
+esac
+
 echo Settings:
 echo "making dstro in ${DEST}"
 echo "variant: ${VARIANT}"


### PR DESCRIPTION
Hello!

I have made some improvements to `make_custom_pi_os` after having some friction getting started on macos:

## Improve portability of make_custom_pi_os

- Use `which` to check for `gsed` and use it if available:
  macos ships with BSD sed which doesn't support `-i` for in-place
  editing
- get the primary group of the current user with `id -gn` instead
  of hardcoding it to `${USER}` - macos doesn't create a group
  with the same name as the user by default
- Add quotes around a bunch of variables to prevent globbing /
  word splitting
- Use `set -euo pipefail` to make the script fail on errors and
  undefined variables, rather than silently continuing
- Use '-s' flag with curl to prevent it from printing the download
  progress bar when retrieving version info
- Check we can retrieve the filename of the latest Raspbian image
  before downloading it
- Print out the URL of the image we're downloading

## Allow specifying variant when creating new custom os

Rather than just the hardcoded `raspios_lite_armhf`, users can now specify
`raspios_lite_armhf` or `raspios_lite_arm64` with `-v/--variant`

## Guard against space / hyphen in the destination folder

This causes some pain, as the default module uses this directory name for creating variables.
If these characters are just disallowed, this pain goes away
