### PR TITLE
more preventing of "apt clean"

### DIFF
--- a/src/modules/base/config
+++ b/src/modules/base/config
@@ -16,7 +16,7 @@ BASE_VERSION=1.5.0
 [ -n "$BASE_DISTRO" ] || BASE_DISTRO=raspbian
 
 # Note: Set BASE_ZIP_IMG relative to the distro/src/workspace directory to pass a custom named file or an already extracted '.img'-file.
-if [ "${BASE_DISTRO}" == "ubuntu" ]; then
+if [ "${BASE_DISTRO}" = "ubuntu" ]; then
     # Default image ubuntu
     [ -n "$BASE_ZIP_IMG" ] || BASE_ZIP_IMG=`ls -t $BASE_IMAGE_PATH/ubuntu-*.xz | head -n 1`
     # Default user ubuntu
@@ -28,7 +28,7 @@ if [ "${BASE_DISTRO}" == "ubuntu" ]; then
     [ -n "$BASE_USER_PASSWORD" ] || BASE_USER_PASSWORD=ubuntu
 else
     # Default image raspbian
-    if [ "${BASE_DISTRO}" == "raspios64" ]; then
+    if [ "${BASE_DISTRO}" = "raspios64" ]; then
         [ -n "$BASE_ZIP_IMG" ] || BASE_ZIP_IMG=`ls -t $BASE_IMAGE_PATH/*-{raspbian,raspios}-*-arm64-*.{zip,7z,xz} | head -n 1`
     else
         [ -n "$BASE_ZIP_IMG" ] || BASE_ZIP_IMG=`ls -t $BASE_IMAGE_PATH/*-{raspbian,raspios}*.{zip,7z,xz} | head -n 1`
@@ -49,7 +49,7 @@ fi
 # [ -n "$BASE_CHROOT_SCRIPT_PATH" ] || BASE_CHROOT_SCRIPT_PATH=$BASE_SCRIPT_PATH/chroot_script
 [ -n "$BASE_MOUNT_PATH" ] || BASE_MOUNT_PATH=$BASE_WORKSPACE/mount
 
-if [ "${BASE_DISTRO}" == "ubuntu" ]; then
+if [ "${BASE_DISTRO}" = "ubuntu" ]; then
   [ -n "${BASE_BOOT_MOUNT_PATH}" ] || BASE_BOOT_MOUNT_PATH=boot/firmware
 else
   [ -n "${BASE_BOOT_MOUNT_PATH}" ] || BASE_BOOT_MOUNT_PATH=boot

--- a/src/modules/base/config
+++ b/src/modules/base/config
@@ -18,7 +18,7 @@ BASE_VERSION=1.5.0
 # Note: Set BASE_ZIP_IMG relative to the distro/src/workspace directory to pass a custom named file or an already extracted '.img'-file.
 if [ "${BASE_DISTRO}" = "ubuntu" ]; then
     # Default image ubuntu
-    [ -n "$BASE_ZIP_IMG" ] || BASE_ZIP_IMG=`ls -t $BASE_IMAGE_PATH/ubuntu-*.xz | head -n 1`
+    [ -n "$BASE_ZIP_IMG" ] || BASE_ZIP_IMG=$(ls -t $BASE_IMAGE_PATH/ubuntu-*.xz | head -n 1)
     # Default user ubuntu
     [ -n "$BASE_USER" ] || BASE_USER=ubuntu
     
@@ -29,9 +29,9 @@ if [ "${BASE_DISTRO}" = "ubuntu" ]; then
 else
     # Default image raspbian
     if [ "${BASE_DISTRO}" = "raspios64" ]; then
-        [ -n "$BASE_ZIP_IMG" ] || BASE_ZIP_IMG=`ls -t $BASE_IMAGE_PATH/*-{raspbian,raspios}-*-arm64-*.{zip,7z,xz} | head -n 1`
+        [ -n "$BASE_ZIP_IMG" ] || BASE_ZIP_IMG=$(ls -t $BASE_IMAGE_PATH/*-{raspbian,raspios}-*-arm64-*.{zip,7z,xz} | head -n 1)
     else
-        [ -n "$BASE_ZIP_IMG" ] || BASE_ZIP_IMG=`ls -t $BASE_IMAGE_PATH/*-{raspbian,raspios}*.{zip,7z,xz} | head -n 1`
+        [ -n "$BASE_ZIP_IMG" ] || BASE_ZIP_IMG=$(ls -t $BASE_IMAGE_PATH/*-{raspbian,raspios}*.{zip,7z,xz} | head -n 1)
     fi
     # Default user raspbian
     [ -n "$BASE_USER" ] || BASE_USER=pi
@@ -85,7 +85,7 @@ fi
 [ -n "$BASE_SSH_ENABLE" ] || BASE_SSH_ENABLE=yes
 
 #Store the commit used for CustomPiOS
-[ -n "$BASE_COMMIT" ] || BASE_COMMIT=`pushd "${CUSTOM_PI_OS_PATH}" > /dev/null ; git rev-parse HEAD ; popd > /dev/null`
+[ -n "$BASE_COMMIT" ] || BASE_COMMIT=$(git -C "${CUSTOM_PI_OS_PATH}" rev-parse HEAD)
 
 #Memory split
 [ -n "$BASE_CONFIG_MEMSPLIT" ] || BASE_CONFIG_MEMSPLIT=default

--- a/src/modules/base/config
+++ b/src/modules/base/config
@@ -107,3 +107,7 @@ fi
 
 # Enable uart console on boot
 [ -n "$BASE_ENABLE_UART" ] || BASE_ENABLE_UART=no
+
+
+# Clean apt-cache after all the work is done
+: ${BASE_APT_CLEAN:=yes}

--- a/src/modules/base/end_chroot_script
+++ b/src/modules/base/end_chroot_script
@@ -39,5 +39,7 @@ if [ "${BASE_DISTRO}" == "ubuntu" ];then
 fi
 
 #cleanup
-apt-get clean
+if [ "${BASE_APT_CLEAN}" = "yes" ]; then
+    apt-get clean
+fi
 apt-get autoremove -y


### PR DESCRIPTION
While b47534cc33a0b65ea5d2ee107cefda66470cb226 provides a `PKGUPGRADE_CLEANUP` variable to prevent the `pkgupgrade` module from running `apt-get clean` in the cleanpu script, the `base` module still unconditionally clears the apt-cache: https://github.com/guysoft/CustomPiOS/blob/8a3a002570c46409372349853622f0619baefc87/src/modules/base/end_chroot_script#L41-L42

This PR introduces a new `BASE_APT_CLEAN` variable, that can be set to anything but the default `yes` to prevent `apt-get clean` from being run.

while I edited the files i couldn't resist the urge to drop some unnecessary bashisms and replace the oldstyle command substitution ` `` ` with the modern, stackable ` $() ` (but these changes are in separate commits, so feel free to ignore them)