### PR TITLE
Fix permission of generated image to to 644

### DIFF
--- a/src/custompios
+++ b/src/custompios
@@ -204,7 +204,7 @@ pushd $BASE_WORKSPACE
   
   # unmount first boot, then root partition
   unmount_image $BASE_MOUNT_PATH
-  chmod 777 $BASE_IMG_PATH
+  chmod 644 $BASE_IMG_PATH
 
   if [ -n "$BASE_IMAGE_RESIZEROOT" ]
   then


### PR DESCRIPTION
- everybody should probably be able to read the file
- **not** everybody (esp. not "others") should be able to write the generated file
- nobody needs to be able to execute the file

Closes: https://github.com/guysoft/CustomPiOS/issues/211