### PR TITLE
fix: fix chroot mount points

### DIFF
--- a/src/common.sh
+++ b/src/common.sh
@@ -203,10 +203,11 @@ function mount_image() {
 	  sudo mount -o loop,offset=$boot_offset,sizelimit=$( expr $root_offset - $boot_offset ) "${image_path}" "${mount_path}"/"${boot_mount_path}"
   fi
   sudo mkdir -p $mount_path/dev/pts
-  sudo mkdir -p $mount_path/proc
+  sudo mount -t proc none $mount_path/proc
+  sudo mount -t sysfs none $mount_path/sys
   sudo mount -o bind /dev $mount_path/dev
   sudo mount -o bind /dev/pts $mount_path/dev/pts
-  sudo mount -o bind /proc $mount_path/proc
+  sudo mount -o bind /run $mount_path/run
 }
 
 function unmount_image() {


### PR DESCRIPTION
Armbian based images fail to build during DNS resolution. This is caused by their packages. DNS resolution is provided by 'systemd-resolved', which obviously can not be run inside a chroot. Therefore it needs to have access to the underlying one due proc and run fs mounts.