### PR TITLE
fix: fix handling of resolv.conf file

### DIFF
--- a/src/modules/base/end_chroot_script
+++ b/src/modules/base/end_chroot_script
@@ -38,6 +38,17 @@ if [ "${BASE_DISTRO}" == "ubuntu" ];then
     echo "127.0.0.1 ${BASE_OVERRIDE_HOSTNAME}" > /etc/hosts
 fi
 
+# restore resolve.conf
+if [ -f /.resolvconf_link ]; then
+  resolvconf_target="$(cat /.resolvconf_link)"
+  ln -sf "${resolvconf_target}" /etc/resolv.conf 2>/dev/null
+  rm -f /.resolvconf_link
+else
+  if [ -f /etc/resolv.conf.orig ]; then
+    mv /etc/resolv.conf.orig /etc/resolv.conf
+  fi
+fi
+
 #cleanup
 if [ "${BASE_APT_CLEAN}" = "yes" ]; then
     apt-get clean

--- a/src/modules/base/start_chroot_script
+++ b/src/modules/base/start_chroot_script
@@ -16,22 +16,27 @@ if [ -n "${BASE_APT_MIRROR}" ]; then
    mv /tmp/filename.tmp /etc/apt/sources.list
 fi
 
-if [ "${BASE_DISTRO}" == "ubuntu" ]; then
-  unpack /filesystem/ubuntu / root
-
-  mv /etc/resolv.conf /etc/resolv.conf.orig || true
+function generate_resolvconf {
   if [ -z "${BASE_USE_ALT_DNS}" ]; then
-    echo "nameserver 8.8.8.8" > /etc/resolv.conf
-    echo "nameserver 8.8.4.4" >> /etc/resolv.conf
-    echo "nameserver 1.1.1.1" >> /etc/resolv.conf
+    touch /etc/resolv.conf
+    for dns in 8.8.8.8 8.8.4.4 1.1.1.1; do
+      echo "nameserver ${dns}" >> /etc/resolv.conf
+    done
   else
     touch /etc/resolv.conf
     for dns in ${BASE_USE_ALT_DNS}; do
       echo "nameserver ${dns}" >> /etc/resolv.conf
     done
   fi
+}
 
-  
+if [ "${BASE_DISTRO}" == "ubuntu" ]; then
+  unpack /filesystem/ubuntu / root
+
+  mv /etc/resolv.conf /etc/resolv.conf.orig || true
+
+  generate_resolvconf
+
   apt-get update --allow-releaseinfo-change
   apt-get install -y net-tools wireless-tools dhcpcd5
   if [ $( is_in_apt policykit-1 ) -eq 1 ]; then
@@ -46,6 +51,20 @@ if [ "${BASE_DISTRO}" == "ubuntu" ]; then
   #Undo prevent any installed services from automatically starting
   rm -r /usr/sbin/policy-rc.d || true
   
+fi
+
+if [ "${BASE_DISTRO}" != "ubuntu" ]; then
+  # Armbian > 24.5 workaround
+  if [ -h /etc/resolv.conf ]; then
+    link_target="$(ls -l /etc/resolv.conf | cut -f2 -d">" | sed 's/^[[:space:]]//')"
+    echo "${link_target}" > /.resolvconf_link
+    rm -f /etc/resolv.conf
+  else
+    mv /etc/resolv.conf /etc/resolv.conf.orig || true
+  fi
+
+  generate_resolvconf
+
 fi
 
 #Helper Function for create_userconf


### PR DESCRIPTION
Includes changes if resolv.conf is a symbolic link

Mostly affected are armbian based images.

If you want to go through whole logs of build please see:

https://github.com/KwadFan/MainsailOS-dev/actions/runs/10264062537

As earlier said on discord:

What it does:
1. Checking if resolv.conf is a symlink, if yes store target location in a temporary file on /
2. Altering resolv.conf, based on setup either your desired default or based on `BASE_USE_ALT_DNS`
3. After all desired modules, running end_chroot and restore either link or backuped resolv.conf(depending if temporary file exist)

I think this is less invasive as PR #224
Regards Kwad