### PR TITLE
qemu-arm-static isn't needed when already on an arm64 box

### DIFF
--- a/src/custompios
+++ b/src/custompios
@@ -39,8 +39,6 @@ function execute_chroot_script() {
     elif [ "$BASE_ARCH" == "aarch64" ] || [ "$BASE_ARCH" == "arm64" ]; then
       if (grep -q gentoo /etc/os-release);then
         ROOT="`realpath .`" emerge --usepkgonly --oneshot --nodeps qemu
-      else
-        cp `which qemu-aarch64-static` usr/bin/qemu-aarch64-static
       fi
     fi
   fi


### PR DESCRIPTION
When building a Pi image, if you're already on an arm64/aarch64 system, there's no need to try to install/use `qemu-arm-static` binary for the build.