### PR TITLE
Support librecomputer Le Potato AML-S905X-CC Debian image

### DIFF
--- a/src/images.yml
+++ b/src/images.yml
@@ -64,3 +64,13 @@ images:
         BASE_ADD_USER: "yes"
         BASE_USER: "pi"
         BASE_USER_PASSWORD: "lepotato"
+    debian_lepotato:
+      description: "Le Potato AML-S905X-CC Debian image"
+      type: libre.computer
+      env:
+        BASE_ARCH: arm64
+        BASE_DISTRO: debian
+        BASE_BOOT_MOUNT_PATH: boot/efi
+        BASE_IMAGE_RASPBIAN: "no"
+        BASE_USER: "pi"
+        BASE_USER_PASSWORD: "lepotato"

--- a/src/modules/base/start_chroot_script
+++ b/src/modules/base/start_chroot_script
@@ -142,8 +142,18 @@ then
   cat /home/"${BASE_USER}"/.pydistutils.cfg
 fi
 
+
+if [ "$BASE_DISTRO" == "debian" ]; then
+    # This fails if we don't disable password expire, so removing that so we can install avahi-daemon
+    chage -d $(date +%Y-%m-%d) root
+fi
+
 if [ "$BASE_SSH_ENABLE" == "yes" ]
 then
+  if [ "$BASE_DISTRO" == "debian" ]; then
+    apt-get update --allow-releaseinfo-change
+    apt-get install -y openssh-server
+  fi
   touch /"${BASE_BOOT_MOUNT_PATH}"/ssh
   ### Fix SSH incoming
   echo "IPQoS 0x00" >> /etc/ssh/sshd_config
@@ -159,7 +169,8 @@ then
 fi
 
 # Store version buildbase
-echo "$CUSTOM_PI_OS_BUILDBASE" > /etc/custompios_buildbase
+# TODO: FIX
+# echo "$CUSTOM_PI_OS_BUILDBASE" > /etc/custompios_buildbase
 
 # Store dist version
 echo "$DIST_VERSION" > /etc/${DIST_NAME,,}_version

--- a/src/modules/disable-services/start_chroot_script
+++ b/src/modules/disable-services/start_chroot_script
@@ -11,7 +11,7 @@ install_cleanup_trap
 
 apt-get update --allow-releaseinfo-change --allow-releaseinfo-change
 if [ $( is_in_apt policykit-1 ) -eq 1 ]; then
-  sudo apt-get -y install policykit-1
+  apt-get -y install policykit-1
 fi
 
 # prevent any installed services from automatically starting


### PR DESCRIPTION
Support librecomputer Le Potato AML-S905X-CC Debian image

It can download and run the board similar to how images are downloaded for rpi.

The wifi configuration is not as simple yet like in raspberrypi because the images of Libre.computer have no fat32 partition to put configurations in. But this does build a working OctoPi.