### PR TITLE
Mounting sys directory to allow building of arm64 images

### DIFF
--- a/src/common.sh
+++ b/src/common.sh
@@ -207,9 +207,11 @@ function mount_image() {
   fi
   sudo mkdir -p $mount_path/dev/pts
   sudo mkdir -p $mount_path/proc
+  sudo mkdir -p $mount_path/sys
   sudo mount -o bind /dev $mount_path/dev
   sudo mount -o bind /dev/pts $mount_path/dev/pts
   sudo mount -o bind /proc $mount_path/proc
+  sudo mount -o bind /sys $mount_path/sys
 }
 
 function unmount_image() {


### PR DESCRIPTION
When attempting to update in the `base` module the update of `initramfs-tools` fails due to the lack of a `sys` mount. Added mounts to `common.sh` to allow the update to continue successfully