### PR TITLE
Fix aarch/arm64 Architecture Issues

### DIFF
--- a/src/build
+++ b/src/build
@@ -8,6 +8,11 @@ set -x
 
 define(){ IFS='\n' read -r -d '' ${1} || true; }
 
+# Source in dist config to seed generate_board_config.py
+# but will then be overwritten ${CUSTOM_PI_OS_PATH}/config for
+# 'final' configuration
+source ${DIST_PATH}/config
+
 define SCRIPT <<'EOF'
 BUILD_SCRIPT_PATH=$(dirname $(realpath -s $BASH_SOURCE))
 export EXTRA_BOARD_CONFIG=$(mktemp)

--- a/src/custompios
+++ b/src/custompios
@@ -30,8 +30,7 @@ function execute_chroot_script() {
   fi
 
   #black magic of qemu-arm-static
-  # cp `which qemu-arm-static` usr/bin
-  if [ "$(uname -m)" != "armv7l" ] || [ "$(uname -m)" != "aarch64" ] ; then
+  if [ "$(uname -m)" != "armv7l" ] && [ "$(uname -m)" != "aarch64" ] ; then
     if [ "$BASE_ARCH" == "armv7l" ] || [ "$BASE_ARCH" == "armhf" ]; then
       if (grep -q gentoo /etc/os-release);then
         ROOT="`realpath .`" emerge --usepkgonly --oneshot --nodeps qemu
@@ -45,6 +44,8 @@ function execute_chroot_script() {
         cp `which qemu-aarch64-static` usr/bin/qemu-aarch64-static
       fi
     fi
+  elif [[ ( "$BASE_ARCH" == "armv7l" || "$BASE_ARCH" == "armhf" ) && "$(uname -m)" != "armv7l" ]]; then
+    cp `which qemu-aarch64-static` usr/bin/qemu-aarch64-static
   fi
   
   cp $2 chroot_script
@@ -74,7 +75,7 @@ function execute_chroot_script() {
         echo "Unknown arch, building on: $(uname -m) image: $BASE_ARCH"
 	exit 1
     fi
-  elif { [ "$BASE_ARCH" == "armv7l" ] || [ "$BASE_ARCH" == "armhf" ]; }  && [ "$(uname -m)" != "armv7l" ]; then
+  elif [[ ( "${BASE_ARCH}" == "armv7l" || "${BASE_ARCH}" == "armhf" ) && "$(uname -m)" != "armv7l" ]]; then
     echo "Building on aarch64/arm64 device a armv7l system, using qemu-arm-static"
     chroot . usr/bin/qemu-arm-static /bin/bash /chroot_script
   else


### PR DESCRIPTION
This pull request addresses two things:

- Fixed the architecture mismatch in #239 by adding a statement to read the basic config in before generating the board-related configuration
- A better fix for the logic on when qemu-arm-static isn't needed (e.g. building an aarch64 image on an aarch64 system). This replaces my old pull #228 