### PR TITLE
Create NETWORK_ENABLE_NTP_QUIRKS option

### DIFF
--- a/src/modules/network/config
+++ b/src/modules/network/config
@@ -17,3 +17,6 @@
 
 # Enable Network Manager boot folder support (bookworm)
 [ -n "$NETWORK_NETWORK_MANAGER" ] || NETWORK_NETWORK_MANAGER=yes
+
+# Enable/Disable rc.local/NTP quirks code
+[ -n "$NETWORK_ENABLE_NTP_QUIRKS" ] || NETWORK_ENABLE_NTP_QUIRKS=no

--- a/src/modules/network/start_chroot_script
+++ b/src/modules/network/start_chroot_script
@@ -49,16 +49,18 @@ fi
 [ -f /etc/ifplugd/action.d/ifupdown ] && mv /etc/ifplugd/action.d/ifupdown /etc/ifplugd/action.d/ifupdown.original
 [ -f /etc/wpa_supplicant/ifupdown.sh ] && ln -s /etc/wpa_supplicant/ifupdown.sh /etc/ifplugd/action.d/ifupdown
 
-if [ ! -f "/etc/rc.local" ];then
-  echo 'exit 0' >> /etc/rc.local
+if [ "$NETWORK_ENABLE_NTP_QUIRKS" == "yes" ]; then
+	if [ ! -f "/etc/rc.local" ];then
+	  echo 'exit 0' >> /etc/rc.local
+	fi
+	
+	# prevent ntp updates from failing due to some Rpi3 weirdness, see also "Fix SSH" further below
+	apt-get update --allow-releaseinfo-change
+	apt-get install -y iptables
+	sed -i 's@exit 0@@' /etc/rc.local
+	echo '/sbin/iptables -t mangle -I POSTROUTING 1 -o wlan0 -p udp --dport 123 -j TOS --set-tos 0x00' >> /etc/rc.local
+	echo 'exit 0' >> /etc/rc.local
 fi
-
-# prevent ntp updates from failing due to some Rpi3 weirdness, see also "Fix SSH" further below
-apt-get update --allow-releaseinfo-change
-apt-get install -y iptables
-sed -i 's@exit 0@@' /etc/rc.local
-echo '/sbin/iptables -t mangle -I POSTROUTING 1 -o wlan0 -p udp --dport 123 -j TOS --set-tos 0x00' >> /etc/rc.local
-echo 'exit 0' >> /etc/rc.local
 
 # Install powersave option
 if [ "$NETWORK_DISABLE_PWRSAVE" == "yes" ]; then

--- a/src/modules/network/start_chroot_script
+++ b/src/modules/network/start_chroot_script
@@ -61,8 +61,8 @@ if [ "${BASE_DISTRO}" == "raspbian" ]; then
 fi
 
 if [ "$NETWORK_ENABLE_NTP_QUIRKS" == "yes" ]; then
-	if [ ! -f "/etc/rc.local" ];then
-	  echo 'exit 0' >> /etc/rc.local
+	if [ ! -f "/etc/rc.local" ]; then
+	  echo '#!/bin/sh -e' > /etc/rc.local
 	fi
 	
 	# prevent ntp updates from failing due to some Rpi3 weirdness, see also "Fix SSH" further below

--- a/src/modules/network/start_chroot_script
+++ b/src/modules/network/start_chroot_script
@@ -82,6 +82,9 @@ if [ "$NETWORK_DISABLE_PWRSAVE" == "yes" ]; then
   # Use rc.local
   if [ "$NETWORK_PWRSAVE_TYPE" == "rclocal" ]; then
     echo_green "Modifying /etc/rc.local ..."
+	if [ ! -f "/etc/rc.local" ]; then
+      echo '#!/bin/sh -e' > /etc/rc.local
+    fi
     sed -i 's@exit 0@@' /etc/rc.local
     (echo "# Disable WiFi Power Management"; \
     echo 'echo "Disabling power management for wlan0 ..."' ; \


### PR DESCRIPTION
There is obsolete code in `modules/network` that tries to force-mangle iptables for NTP purposes. This adds an option to enable that behavior if desired.