### PR TITLE
Enable Camera Auto Detect

### DIFF
--- a/src/modules/raspicam/start_chroot_script
+++ b/src/modules/raspicam/start_chroot_script
@@ -6,4 +6,4 @@ echo "# enable raspicam" >> /"${BASE_BOOT_MOUNT_PATH}"/config.txt
 echo "start_x=1" >> /"${BASE_BOOT_MOUNT_PATH}"/config.txt
 echo "gpu_mem=128" >> /"${BASE_BOOT_MOUNT_PATH}"/config.txt
 # See why camera_auto_detect=0 https://github.com/guysoft/OctoPi/issues/837#issuecomment-2536532941
-sed -i 's/^camera_auto_detect=.*$/camera_auto_detect=0/' /"${BASE_BOOT_MOUNT_PATH}"/config.txt
+sed -i 's/^camera_auto_detect=.*$/camera_auto_detect=1/' /"${BASE_BOOT_MOUNT_PATH}"/config.txt


### PR DESCRIPTION
Currently camera_auto_detect=0. This disables finding cameras, setting this to 1 to enable cameras to get picked up. 