### PR TITLE
fix: check modules before adding base meta modules

### DIFF
--- a/src/modules/base/meta
+++ b/src/modules/base/meta
@@ -10,9 +10,9 @@ export LC_ALL=C
 
 FINAL_MODULES=()
 
-if [[ "${BASE_BOARD}" = armbian* ]]; then
+if [[ "${BASE_BOARD}" = armbian* && -d "${DIST_PATH}/modules/armbian" ]]; then
     FINAL_MODULES+=("armbian")
-elif [[ "${BASE_BOARD}" = orange* ]]; then
+elif [[ "${BASE_BOARD}" = orange* && -d "${DIST_PATH}/modules/orange" ]]; then
     FINAL_MODULES+=("orange")
 fi
 


### PR DESCRIPTION
This PR just add a condition before adding base meta modules. It just checks if the module exists, before adding it.