### PR TITLE
Fix E2E SSH and post-boot sudo: pi shell + NOPASSWD sudoers in prepare-image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -7,6 +7,7 @@ on:
       - "docker-github-actions"
       - "release/v1"
       - "beta"
+      - "bugfix/e2e"
     tags:
       - "*"
 jobs:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,0 +1,83 @@
+name: E2E Test (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      image-artifact-name:
+        required: true
+        type: string
+      distro-name:
+        required: true
+        type: string
+      docker-context:
+        required: false
+        type: string
+        default: 'testing/'
+      timeout-minutes:
+        required: false
+        type: number
+        default: 45
+      poll-interval:
+        required: false
+        type: number
+        default: 5
+      max-poll-iterations:
+        required: false
+        type: number
+        default: 360
+
+jobs:
+  e2e-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download image from build
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.image-artifact-name }}
+          path: image/
+
+      - name: Build test Docker image
+        run: DOCKER_BUILDKIT=0 docker build -t e2e-test ${{ inputs.docker-context }}
+
+      - name: Start E2E test container
+        run: |
+          mkdir -p artifacts
+          IMG=$(find image/ -name '*.img' | head -1)
+          docker run -d --name e2e-test \
+            -v "$PWD/artifacts:/output" \
+            -v "$(realpath $IMG):/input/image.img:ro" \
+            -e ARTIFACTS_DIR=/output \
+            -e DISTRO_NAME="${{ inputs.distro-name }}" \
+            e2e-test
+
+      - name: Wait for tests to complete
+        run: |
+          for i in $(seq 1 ${{ inputs.max-poll-iterations }}); do
+            [ -f artifacts/exit-code ] && break
+            sleep ${{ inputs.poll-interval }}
+          done
+          if [ ! -f artifacts/exit-code ]; then
+            echo "ERROR: Tests did not complete within timeout"
+            docker logs e2e-test 2>&1 | tail -80
+            exit 1
+          fi
+          echo "Tests finished with exit code: $(cat artifacts/exit-code)"
+          cat artifacts/test-results.txt 2>/dev/null || true
+
+      - name: Collect logs and stop container
+        if: always()
+        run: |
+          docker logs e2e-test > artifacts/container.log 2>&1 || true
+          docker stop e2e-test 2>/dev/null || true
+
+      - name: Check test result
+        run: exit "$(cat artifacts/exit-code 2>/dev/null || echo 1)"
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: e2e-test-results
+          path: artifacts/

--- a/src/distro_testing/scripts/prepare-image.sh
+++ b/src/distro_testing/scripts/prepare-image.sh
@@ -23,6 +23,13 @@ write /etc/fstab "proc /proc proc defaults 0 0\n/dev/vda1 /boot/firmware vfat de
 -rm /etc/systemd/system/multi-user.target.wants/userconfig.service
 -rm /usr/lib/systemd/system/userconfig.service
 
+# userconfig.service is what normally drops /etc/sudoers.d/010_pi-nopasswd.
+# Since we remove it, seed the file ourselves so test scripts (post-boot hooks,
+# apt-get installs, etc.) can use passwordless sudo over a non-TTY SSH session.
+mkdir-p /etc/sudoers.d
+write /etc/sudoers.d/010_pi-nopasswd "pi ALL=(ALL) NOPASSWD: ALL\n"
+chmod 0440 /etc/sudoers.d/010_pi-nopasswd
+
 mkdir-p /etc/ssh/sshd_config.d
 write /etc/ssh/sshd_config.d/99-qemu-test.conf "PasswordAuthentication yes\nPermitRootLogin yes\nKbdInteractiveAuthentication yes\n"
 

--- a/src/distro_testing/scripts/prepare-image.sh
+++ b/src/distro_testing/scripts/prepare-image.sh
@@ -71,17 +71,20 @@ chmod 0644 /etc/ssh/ssh_host_ecdsa_key.pub
 chmod 0644 /etc/ssh/ssh_host_ed25519_key.pub
 
 download /etc/shadow /tmp/shadow.bak
+download /etc/passwd /tmp/passwd.bak
 
 umount /
 GFEOF
 
-echo 'Setting pi user password...'
+echo 'Setting pi user password and shell...'
 sed -i "s|^pi:[^:]*:|pi:${PIPASS}:|" /tmp/shadow.bak
+sed -i 's|^pi:\(.*\):/usr/sbin/nologin$|pi:\1:/bin/bash|' /tmp/passwd.bak
 
 guestfish -a "$OUTPUT_IMAGE" <<GFEOF2
 run
 mount /dev/sda2 /
 upload /tmp/shadow.bak /etc/shadow
+upload /tmp/passwd.bak /etc/passwd
 umount /
 GFEOF2
 

--- a/src/distro_testing/scripts/ssh-helpers.sh
+++ b/src/distro_testing/scripts/ssh-helpers.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Shared SSH helpers for E2E test scripts.
+# Source this file: source /test/scripts/ssh-helpers.sh
+#
+# Set E2E_SSH_HOST, E2E_SSH_PORT, E2E_SSH_USER, E2E_SSH_PASS before sourcing
+# to override defaults. Test scripts typically do:
+#   export E2E_SSH_HOST="${1:-localhost}"
+#   export E2E_SSH_PORT="${2:-2222}"
+#   source /test/scripts/ssh-helpers.sh
+
+E2E_SSH_HOST="${E2E_SSH_HOST:-localhost}"
+E2E_SSH_PORT="${E2E_SSH_PORT:-2222}"
+E2E_SSH_USER="${E2E_SSH_USER:-pi}"
+E2E_SSH_PASS="${E2E_SSH_PASS:-raspberry}"
+
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+  -o PreferredAuthentications=password -o PubkeyAuthentication=no \
+  -o ConnectTimeout=10 -o LogLevel=ERROR"
+
+ssh_cmd() {
+  sshpass -p "$E2E_SSH_PASS" ssh $SSH_OPTS -p "$E2E_SSH_PORT" "${E2E_SSH_USER}@${E2E_SSH_HOST}" "$@"
+}
+
+scp_cmd() {
+  sshpass -p "$E2E_SSH_PASS" scp $SSH_OPTS -P "$E2E_SSH_PORT" "$@"
+}

--- a/src/distro_testing/tests/test_boot.sh
+++ b/src/distro_testing/tests/test_boot.sh
@@ -1,16 +1,15 @@
 #!/bin/bash
 set -e
 
-HOST="${1:-localhost}"
-PORT="${2:-2222}"
-USER="pi"
-PASS="raspberry"
+export E2E_SSH_HOST="${1:-localhost}"
+export E2E_SSH_PORT="${2:-2222}"
 
-SSH_CMD="sshpass -p $PASS ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o PreferredAuthentications=password -o PubkeyAuthentication=no -o LogLevel=ERROR -p $PORT ${USER}@${HOST}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$(dirname "$SCRIPT_DIR")/scripts/ssh-helpers.sh"
 
 echo "Test: SSH login and run 'echo hello world'"
 
-OUTPUT=$($SSH_CMD 'echo hello world' 2>/dev/null)
+OUTPUT=$(ssh_cmd 'echo hello world' 2>/dev/null)
 
 if [ "$OUTPUT" = "hello world" ]; then
     echo "  Output: '$OUTPUT'"


### PR DESCRIPTION
## Summary

Fixes the shared E2E test framework SSH stage and post-boot sudo, which were both broken by the combination of Raspberry Pi OS Trixie defaults and the headless `userconfig.service` removal we do in `prepare-image.sh`.

## Root causes

1. **SSH login failed for `pi`.** RPi OS Trixie ships the `pi` user with `/usr/sbin/nologin` as the default shell. The first-boot `userconfig.service` would normally rewrite it, but `src/distro_testing/scripts/prepare-image.sh` removes that service. Result: SSH authenticates but every session prints `This account is currently not available.` and exits 1, timing out the wait-for-ssh stage. Reproduced in FullPageOS run [24418025784](https://github.com/guysoft/FullPageOS/actions/runs/24418025784).

2. **`sudo` from the `pi` user required a password.** `userconfig.service` is also what normally drops `/etc/sudoers.d/010_pi-nopasswd`. With that service removed, `sudo apt-get install ...` and similar calls from post-boot hooks fail over non-TTY SSH (`sudo: a terminal is required to read the password`). This was previously masked by the SSH timeout above.

## Fix

In `src/distro_testing/scripts/prepare-image.sh`:

- Download `/etc/passwd` alongside `/etc/shadow`, sed-replace `:/usr/sbin/nologin` -> `:/bin/bash` for the `pi` user, re-upload.
- Add a guestfish `write /etc/sudoers.d/010_pi-nopasswd "pi ALL=(ALL) NOPASSWD: ALL\n"` with `chmod 0440`.

## Verification

Built `ghcr.io/guysoft/custompios:bugfix-e2e` from this branch, pointed FullPageOS `test/e2e-bugfix` at it. FullPageOS run [26096890001](https://github.com/guysoft/FullPageOS/actions/runs/26096890001) is fully green:

- `SSH is ready (took 98s)` (previously: 600s timeout)
- `test_boot.sh` -> PASSED
- `test_chromium.sh` -> PASSED (matchbox window detected, chromium kiosk running)
- `test_lighttpd.sh` -> PASSED
- `ALL TESTS PASSED`

## Commits in this PR

- `2a87cfb` Fix E2E SSH: set pi user shell to /bin/bash in prepare-image (cherry-picked from `feature/e2e`).
- `4f055f3` Seed /etc/sudoers.d/010_pi-nopasswd in prepare-image.
- `3b7827d` Add reusable E2E workflow, SSH helpers, and CI trigger for feature/e2e (cherry-picked from `feature/e2e`; needed because distros source `ssh-helpers.sh` from the docker image).
- `82c0ebf` ci: build docker image for bugfix/e2e branch (can be reverted on merge if desired, or left as a no-op once this branch is gone).
